### PR TITLE
Always passing indx to PrimoEngine

### DIFF
--- a/app/search_engines/bento_search/primo_engine.rb
+++ b/app/search_engines/bento_search/primo_engine.rb
@@ -240,15 +240,13 @@ class BentoSearch::PrimoEngine
     url = "http://#{configuration.host_port}/PrimoWebServices/xservice/search/brief"
     url += "?institution=#{configuration.institution}"
     url += "&loc=#{CGI.escape configuration.loc}"
-    
+
     url += "&lang=#{CGI.escape configuration.lang}"
     
     url += "&bulkSize=#{args[:per_page]}" if args[:per_page]
     # primo indx is 1-based record index, our :start is 0-based.
-    url += "&indx=#{args[:start] + 1}" if args[:start]
-    
+    url += "&indx=#{args[:start].to_i + 1}"
 
-    
     if (defn = self.sort_definitions[ args[:sort] ]) &&
         (value = defn[:implementation])
       
@@ -274,8 +272,8 @@ class BentoSearch::PrimoEngine
         url += "&#{CGI.escape key.to_s}=#{CGI.escape v.to_s}"
       end
     end
-    
-    
+
+
     return url
   end
   

--- a/test/search_engines/primo_engine_test.rb
+++ b/test/search_engines/primo_engine_test.rb
@@ -42,7 +42,7 @@ class PrimoEngineTest < ActiveSupport::TestCase
     # not every result has every field, but at time we recorded
     # with VCR, this result for this search did. Sorry, a bit fragile. 
     # publisher
-    %w{format_str format title authors volume issue start_page end_page journal_title issn doi abstract unique_id}.each do |attr|
+    %w{format_str format title authors volume issue start_page journal_title issn unique_id}.each do |attr|
       assert_present first.send(attr), "must have #{attr}"
     end
     

--- a/test/vcr_cassettes/primo/proper_tags_for_snippets.yml
+++ b/test/vcr_cassettes/primo/proper_tags_for_snippets.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://example.org/PrimoWebServices/xservice/search/brief?bulkSize=10&highlight=true&institution=DUMMY_INSTITUTION&lang=eng&loc=adaptor,primo_central_multiple_fe&onCampus=false&query=any,contains,cancer
+    uri: http://example.org/PrimoWebServices/xservice/search/brief?bulkSize=10&highlight=true&indx=1&institution=DUMMY_INSTITUTION&lang=eng&loc=adaptor,primo_central_multiple_fe&onCampus=false&query=any,contains,cancer
     body:
       encoding: US-ASCII
       string: ''
@@ -13,12 +13,10 @@ http_interactions:
       message: !binary |-
         T0s=
     headers:
-      !binary "U2VydmVy":
-      - !binary |-
-        QXBhY2hlLUNveW90ZS8xLjE=
       !binary "WC1Qb3dlcmVkLUJ5":
       - !binary |-
-        U2VydmxldCAyLjU7IEpCb3NzLTUuMC9KQm9zc1dlYi0yLjE=
+        U2VydmxldCAyLjQ7IFRvbWNhdC01LjAuMjgvSkJvc3MtNC4wLjEgKGJ1aWxk
+        OiBDVlNUYWc9SkJvc3NfNF8wXzEgZGF0ZT0yMDA0MTIyMzA5NDQp
       !binary "Q29udGVudC1UeXBl":
       - !binary |-
         dGV4dC94bWw7Y2hhcnNldD1VVEYtOA==
@@ -27,203 +25,268 @@ http_interactions:
         Y2h1bmtlZA==
       !binary "RGF0ZQ==":
       - !binary |-
-        V2VkLCAxOSBTZXAgMjAxMiAwNDo0MjowOCBHTVQ=
+        VHVlLCAwNyBNYXkgMjAxMyAwMzoyMDo0OSBHTVQ=
+      !binary "U2VydmVy":
+      - !binary |-
+        QXBhY2hlLUNveW90ZS8xLjE=
     body:
       encoding: UTF-8
-      string: ! "<sear:SEGMENTS xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
-        xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\" xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\">\n
-        \ <sear:JAGROOT>\n    <sear:RESULT>\n      <sear:QUERYTRANSFORMS/>\n      <sear:FACETLIST
-        ACCURATE_COUNTERS=\"true\">\n        <sear:FACET COUNT=\"20\" NAME=\"creator\">\n
-        \         <sear:FACET_VALUES VALUE=\"2\" KEY=\"Torrie, Alfred\"/>\n          <sear:FACET_VALUES
-        VALUE=\"7\" KEY=\"Bernd Pulverer\"/>\n          <sear:FACET_VALUES VALUE=\"11\"
-        KEY=\"Lewith, G.T.\"/>\n          <sear:FACET_VALUES VALUE=\"2\" KEY=\"Baker,
-        HazelB.\"/>\n          <sear:FACET_VALUES VALUE=\"369\" KEY=\"American Cancer
-        Society\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"Chris Surridge\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"1\" KEY=\"Silverthorne, Elizabeth\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"26\" KEY=\"Wiley Online Library\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"7\" KEY=\"Mansberg, Ginni\"/>\n          <sear:FACET_VALUES
-        VALUE=\"2\" KEY=\"Lesley Anson\"/>\n          <sear:FACET_VALUES VALUE=\"4\"
-        KEY=\"Allen, Liz\"/>\n          <sear:FACET_VALUES VALUE=\"12\" KEY=\"Taylor,
-        Grantley W.\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"Surridge,
-        Chris\"/>\n          <sear:FACET_VALUES VALUE=\"2\" KEY=\"Lawrence, Deborah\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"107\" KEY=\"Lawrence, D.\"/>\n          <sear:FACET_VALUES
-        VALUE=\"2\" KEY=\"Amelie G., Victor L.\"/>\n          <sear:FACET_VALUES VALUE=\"2\"
-        KEY=\"Anson, L\"/>\n          <sear:FACET_VALUES VALUE=\"27\" KEY=\"Wiley
-        Interscience\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"Liz Allen\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"90\" KEY=\"Williams, C J\"/>\n        </sear:FACET>\n
-        \       <sear:FACET COUNT=\"1\" NAME=\"lcc\">\n          <sear:FACET_VALUES
-        VALUE=\"3303\" KEY=\"R - Medicine.\"/>\n        </sear:FACET>\n        <sear:FACET
-        COUNT=\"30\" NAME=\"lang\">\n          <sear:FACET_VALUES VALUE=\"303\" KEY=\"ukr\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"2\" KEY=\"tgl\"/>\n          <sear:FACET_VALUES
-        VALUE=\"3\" KEY=\"scr\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"slo\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"4310\" KEY=\"por\"/>\n          <sear:FACET_VALUES
-        VALUE=\"423\" KEY=\"fin\"/>\n          <sear:FACET_VALUES VALUE=\"532\" KEY=\"heb\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"70026\" KEY=\"fre\"/>\n          <sear:FACET_VALUES
-        VALUE=\"780\" KEY=\"rum\"/>\n          <sear:FACET_VALUES VALUE=\"2197\" KEY=\"kor\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"16735\" KEY=\"rus\"/>\n          <sear:FACET_VALUES
-        VALUE=\"20\" KEY=\"ara\"/>\n          <sear:FACET_VALUES VALUE=\"5364\" KEY=\"pol\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"4905135\" KEY=\"eng\"/>\n          <sear:FACET_VALUES
-        VALUE=\"1\" KEY=\"vie\"/>\n          <sear:FACET_VALUES VALUE=\"30143\" KEY=\"spa\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"159\" KEY=\"lit\"/>\n          <sear:FACET_VALUES
-        VALUE=\"1433\" KEY=\"hun\"/>\n          <sear:FACET_VALUES VALUE=\"56246\"
-        KEY=\"ger\"/>\n          <sear:FACET_VALUES VALUE=\"230\" KEY=\"tur\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"2\" KEY=\"ben\"/>\n          <sear:FACET_VALUES
-        VALUE=\"83\" KEY=\"gre\"/>\n          <sear:FACET_VALUES VALUE=\"1227\" KEY=\"nor\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"23\" KEY=\"per\"/>\n          <sear:FACET_VALUES
-        VALUE=\"8\" KEY=\"tha\"/>\n          <sear:FACET_VALUES VALUE=\"1694\" KEY=\"dut\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"1929\" KEY=\"dan\"/>\n          <sear:FACET_VALUES
-        VALUE=\"7184\" KEY=\"ita\"/>\n          <sear:FACET_VALUES VALUE=\"167416\"
-        KEY=\"chi\"/>\n          <sear:FACET_VALUES VALUE=\"51260\" KEY=\"jpn\"/>\n
-        \       </sear:FACET>\n        <sear:FACET COUNT=\"17\" NAME=\"rtype\">\n
-        \         <sear:FACET_VALUES VALUE=\"52674\" KEY=\"books\"/>\n          <sear:FACET_VALUES
-        VALUE=\"168044\" KEY=\"reviews\"/>\n          <sear:FACET_VALUES VALUE=\"3481530\"
-        KEY=\"articles\"/>\n          <sear:FACET_VALUES VALUE=\"2789\" KEY=\"journals\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"13410\" KEY=\"other\"/>\n          <sear:FACET_VALUES
-        VALUE=\"328992\" KEY=\"text_resources\"/>\n          <sear:FACET_VALUES VALUE=\"1183\"
-        KEY=\"websites\"/>\n          <sear:FACET_VALUES VALUE=\"2061475\" KEY=\"newspaper_articles\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"176\" KEY=\"legal_documents\"/>\n          <sear:FACET_VALUES
-        VALUE=\"39168\" KEY=\"reference_entrys\"/>\n          <sear:FACET_VALUES VALUE=\"3\"
+      string: ! "<sear:SEGMENTS xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
+        xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n
+        \ <sear:JAGROOT>\n    <sear:RESULT>\n      <sear:FACETLIST ACCURATE_COUNTERS=\"true\">\n
+        \       <sear:FACET COUNT=\"19\" NAME=\"creator\">\n          <sear:FACET_VALUES
+        VALUE=\"8\" KEY=\"Bernd Pulverer\"/>\n          <sear:FACET_VALUES VALUE=\"352\"
+        KEY=\"American Cancer Society\"/>\n          <sear:FACET_VALUES VALUE=\"3\"
+        KEY=\"Anson, Lesley\"/>\n          <sear:FACET_VALUES VALUE=\"2\" KEY=\"Chris
+        Surridge\"/>\n          <sear:FACET_VALUES VALUE=\"8\" KEY=\"Browning, Scott
+        M.\"/>\n          <sear:FACET_VALUES VALUE=\"28\" KEY=\"Wiley Online Library\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"3\" KEY=\"Lesley Anson\"/>\n          <sear:FACET_VALUES
+        VALUE=\"6\" KEY=\"Allen, Liz\"/>\n          <sear:FACET_VALUES VALUE=\"20\"
+        KEY=\"Taylor, Grantley W.\"/>\n          <sear:FACET_VALUES VALUE=\"2\" KEY=\"Surridge,
+        Chris\"/>\n          <sear:FACET_VALUES VALUE=\"3\" KEY=\"Lawrence, Deborah\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"1\" KEY=\"Grant, R.N.R.\"/>\n          <sear:FACET_VALUES
+        VALUE=\"11\" KEY=\"Pulverer, Bernd\"/>\n          <sear:FACET_VALUES VALUE=\"27\"
+        KEY=\"Wiley Interscience\"/>\n          <sear:FACET_VALUES VALUE=\"2\" KEY=\"Liz
+        Allen\"/>\n          <sear:FACET_VALUES VALUE=\"111\" KEY=\"WILLIAMS, CJ\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"3\" KEY=\"Surridge, C\"/>\n          <sear:FACET_VALUES
+        VALUE=\"45\" KEY=\"TAYLOR, G.W.\"/>\n          <sear:FACET_VALUES VALUE=\"59\"
+        KEY=\"Allen, L\"/>\n        </sear:FACET>\n        <sear:FACET COUNT=\"1\"
+        NAME=\"lcc\">\n          <sear:FACET_VALUES VALUE=\"3426\" KEY=\"R - Medicine.\"/>\n
+        \       </sear:FACET>\n        <sear:FACET COUNT=\"30\" NAME=\"lang\">\n          <sear:FACET_VALUES
+        VALUE=\"3\" KEY=\"tgl\"/>\n          <sear:FACET_VALUES VALUE=\"308\" KEY=\"ukr\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"2\" KEY=\"scr\"/>\n          <sear:FACET_VALUES
+        VALUE=\"1\" KEY=\"slo\"/>\n          <sear:FACET_VALUES VALUE=\"3749\" KEY=\"por\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"442\" KEY=\"fin\"/>\n          <sear:FACET_VALUES
+        VALUE=\"544\" KEY=\"heb\"/>\n          <sear:FACET_VALUES VALUE=\"75886\"
+        KEY=\"fre\"/>\n          <sear:FACET_VALUES VALUE=\"775\" KEY=\"rum\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"1443\" KEY=\"kor\"/>\n          <sear:FACET_VALUES
+        VALUE=\"16852\" KEY=\"rus\"/>\n          <sear:FACET_VALUES VALUE=\"22\" KEY=\"ara\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"5485\" KEY=\"pol\"/>\n          <sear:FACET_VALUES
+        VALUE=\"4562210\" KEY=\"eng\"/>\n          <sear:FACET_VALUES VALUE=\"1\"
+        KEY=\"vie\"/>\n          <sear:FACET_VALUES VALUE=\"26825\" KEY=\"spa\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"100\" KEY=\"lit\"/>\n          <sear:FACET_VALUES
+        VALUE=\"1483\" KEY=\"hun\"/>\n          <sear:FACET_VALUES VALUE=\"67312\"
+        KEY=\"ger\"/>\n          <sear:FACET_VALUES VALUE=\"213\" KEY=\"tur\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"1\" KEY=\"ben\"/>\n          <sear:FACET_VALUES
+        VALUE=\"82\" KEY=\"gre\"/>\n          <sear:FACET_VALUES VALUE=\"1239\" KEY=\"nor\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"114\" KEY=\"per\"/>\n          <sear:FACET_VALUES
+        VALUE=\"7\" KEY=\"tha\"/>\n          <sear:FACET_VALUES VALUE=\"1607\" KEY=\"dut\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"1931\" KEY=\"dan\"/>\n          <sear:FACET_VALUES
+        VALUE=\"7424\" KEY=\"ita\"/>\n          <sear:FACET_VALUES VALUE=\"23423\"
+        KEY=\"chi\"/>\n          <sear:FACET_VALUES VALUE=\"53777\" KEY=\"jpn\"/>\n
+        \       </sear:FACET>\n        <sear:FACET COUNT=\"16\" NAME=\"rtype\">\n
+        \         <sear:FACET_VALUES VALUE=\"17158\" KEY=\"books\"/>\n          <sear:FACET_VALUES
+        VALUE=\"395560\" KEY=\"reviews\"/>\n          <sear:FACET_VALUES VALUE=\"3806783\"
+        KEY=\"articles\"/>\n          <sear:FACET_VALUES VALUE=\"3023\" KEY=\"journals\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"3486\" KEY=\"other\"/>\n          <sear:FACET_VALUES
+        VALUE=\"12407\" KEY=\"dissertations\"/>\n          <sear:FACET_VALUES VALUE=\"405906\"
+        KEY=\"text_resources\"/>\n          <sear:FACET_VALUES VALUE=\"246\" KEY=\"websites\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"878994\" KEY=\"newspaper_articles\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"165\" KEY=\"legal_documents\"/>\n          <sear:FACET_VALUES
+        VALUE=\"4053\" KEY=\"reference_entrys\"/>\n          <sear:FACET_VALUES VALUE=\"3\"
         KEY=\"scores\"/>\n          <sear:FACET_VALUES VALUE=\"13\" KEY=\"maps\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"42\" KEY=\"databases\"/>\n          <sear:FACET_VALUES
-        VALUE=\"20960\" KEY=\"Dissertations\"/>\n          <sear:FACET_VALUES VALUE=\"124\"
-        KEY=\"images\"/>\n          <sear:FACET_VALUES VALUE=\"28953\" KEY=\"conference_proceedings\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"12539\" KEY=\"media\"/>\n        </sear:FACET>\n
-        \       <sear:FACET COUNT=\"20\" NAME=\"topic\">\n          <sear:FACET_VALUES
-        VALUE=\"14039\" KEY=\"Bladder Cancer\"/>\n          <sear:FACET_VALUES VALUE=\"83\"
-        KEY=\"Fitness\"/>\n          <sear:FACET_VALUES VALUE=\"61944\" KEY=\"Chemotherapy\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"843\" KEY=\"Encyclopedias\"/>\n          <sear:FACET_VALUES
-        VALUE=\"155758\" KEY=\"Breast Cancer\"/>\n          <sear:FACET_VALUES VALUE=\"46\"
-        KEY=\"Cancer -- Diagnosis\"/>\n          <sear:FACET_VALUES VALUE=\"139\"
-        KEY=\"Astrology\"/>\n          <sear:FACET_VALUES VALUE=\"17817\" KEY=\"Lymphomas\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"44365\" KEY=\"Oncology\"/>\n          <sear:FACET_VALUES
-        VALUE=\"40\" KEY=\"Cancer -- Prevention\"/>\n          <sear:FACET_VALUES
-        VALUE=\"291775\" KEY=\"Cancer\"/>\n          <sear:FACET_VALUES VALUE=\"2\"
-        KEY=\"Star Cluster\"/>\n          <sear:FACET_VALUES VALUE=\"25\" KEY=\"Constellation\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"96\" KEY=\"Zodiac\"/>\n          <sear:FACET_VALUES
-        VALUE=\"3643\" KEY=\"Mitosis\"/>\n          <sear:FACET_VALUES VALUE=\"49138\"
-        KEY=\"Lung Cancer\"/>\n          <sear:FACET_VALUES VALUE=\"10400\" KEY=\"Thyroid
-        Cancer\"/>\n          <sear:FACET_VALUES VALUE=\"71998\" KEY=\"Prostate Cancer\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"30213\" KEY=\"Medicine\"/>\n          <sear:FACET_VALUES
-        VALUE=\"18466\" KEY=\"Hospitals\"/>\n        </sear:FACET>\n        <sear:FACET
-        COUNT=\"2\" NAME=\"tlevel\">\n          <sear:FACET_VALUES VALUE=\"5060225\"
-        KEY=\"online_resources\"/>\n          <sear:FACET_VALUES VALUE=\"2823666\"
-        KEY=\"peer_reviewed\"/>\n        </sear:FACET>\n        <sear:FACET COUNT=\"15\"
-        NAME=\"pfilter\">\n          <sear:FACET_VALUES VALUE=\"53251\" KEY=\"books\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"168044\" KEY=\"reviews\"/>\n          <sear:FACET_VALUES
-        VALUE=\"3740217\" KEY=\"articles\"/>\n          <sear:FACET_VALUES VALUE=\"2789\"
-        KEY=\"journals\"/>\n          <sear:FACET_VALUES VALUE=\"12539\" KEY=\"audio_video\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"1183\" KEY=\"websites\"/>\n          <sear:FACET_VALUES
-        VALUE=\"2061475\" KEY=\"newspaper_articles\"/>\n          <sear:FACET_VALUES
-        VALUE=\"176\" KEY=\"legal_documents\"/>\n          <sear:FACET_VALUES VALUE=\"39168\"
-        KEY=\"reference_entrys\"/>\n          <sear:FACET_VALUES VALUE=\"3\" KEY=\"scores\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"13\" KEY=\"maps\"/>\n          <sear:FACET_VALUES
-        VALUE=\"42\" KEY=\"databases\"/>\n          <sear:FACET_VALUES VALUE=\"20960\"
-        KEY=\"Dissertations\"/>\n          <sear:FACET_VALUES VALUE=\"28953\" KEY=\"conference_proceedings\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"124\" KEY=\"images\"/>\n        </sear:FACET>\n
+        \         <sear:FACET_VALUES VALUE=\"14\" KEY=\"images\"/>\n          <sear:FACET_VALUES
+        VALUE=\"88237\" KEY=\"conference_proceedings\"/>\n          <sear:FACET_VALUES
+        VALUE=\"12877\" KEY=\"media\"/>\n        </sear:FACET>\n        <sear:FACET
+        COUNT=\"20\" NAME=\"topic\">\n          <sear:FACET_VALUES VALUE=\"19432\"
+        KEY=\"Bladder Cancer\"/>\n          <sear:FACET_VALUES VALUE=\"19356\" KEY=\"Cancer
+        Vaccines\"/>\n          <sear:FACET_VALUES VALUE=\"1502\" KEY=\"Cell Lines\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"172029\" KEY=\"Antineoplastic Agents\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"86937\" KEY=\"Chemotherapy\"/>\n          <sear:FACET_VALUES
+        VALUE=\"172241\" KEY=\"Breast Cancer\"/>\n          <sear:FACET_VALUES VALUE=\"3380\"
+        KEY=\"Hodgkin's Disease\"/>\n          <sear:FACET_VALUES VALUE=\"14201\"
+        KEY=\"Esophageal Cancer\"/>\n          <sear:FACET_VALUES VALUE=\"16773\"
+        KEY=\"Lymphomas\"/>\n          <sear:FACET_VALUES VALUE=\"37508\" KEY=\"Oncology\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"18952\" KEY=\"Cancer Cells\"/>\n          <sear:FACET_VALUES
+        VALUE=\"258728\" KEY=\"Cancer\"/>\n          <sear:FACET_VALUES VALUE=\"6\"
+        KEY=\"Horowitz, Sylvia Teich\"/>\n          <sear:FACET_VALUES VALUE=\"509\"
+        KEY=\"Homeopathy\"/>\n          <sear:FACET_VALUES VALUE=\"35770\" KEY=\"Healthsciences\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"254994\" KEY=\"Neoplasms\"/>\n          <sear:FACET_VALUES
+        VALUE=\"7355\" KEY=\"Childhood Cancer\"/>\n          <sear:FACET_VALUES VALUE=\"11\"
+        KEY=\"Mcallister, Robert M.\"/>\n          <sear:FACET_VALUES VALUE=\"11506\"
+        KEY=\"Thyroid Cancer\"/>\n          <sear:FACET_VALUES VALUE=\"89157\" KEY=\"Prostate
+        Cancer\"/>\n        </sear:FACET>\n        <sear:FACET COUNT=\"2\" NAME=\"tlevel\">\n
+        \         <sear:FACET_VALUES VALUE=\"4107438\" KEY=\"online_resources\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"3375331\" KEY=\"peer_reviewed\"/>\n        </sear:FACET>\n
+        \       <sear:FACET COUNT=\"14\" NAME=\"pfilter\">\n          <sear:FACET_VALUES
+        VALUE=\"17595\" KEY=\"books\"/>\n          <sear:FACET_VALUES VALUE=\"395560\"
+        KEY=\"reviews\"/>\n          <sear:FACET_VALUES VALUE=\"4048198\" KEY=\"articles\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"3023\" KEY=\"journals\"/>\n          <sear:FACET_VALUES
+        VALUE=\"12407\" KEY=\"dissertations\"/>\n          <sear:FACET_VALUES VALUE=\"12877\"
+        KEY=\"audio_video\"/>\n          <sear:FACET_VALUES VALUE=\"246\" KEY=\"websites\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"878994\" KEY=\"newspaper_articles\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"165\" KEY=\"legal_documents\"/>\n          <sear:FACET_VALUES
+        VALUE=\"4053\" KEY=\"reference_entrys\"/>\n          <sear:FACET_VALUES VALUE=\"3\"
+        KEY=\"scores\"/>\n          <sear:FACET_VALUES VALUE=\"13\" KEY=\"maps\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"14\" KEY=\"images\"/>\n          <sear:FACET_VALUES
+        VALUE=\"88237\" KEY=\"conference_proceedings\"/>\n        </sear:FACET>\n
         \       <sear:FACET COUNT=\"75\" NAME=\"creationdate\">\n          <sear:FACET_VALUES
-        VALUE=\"404616\" KEY=\"2008\"/>\n          <sear:FACET_VALUES VALUE=\"475386\"
-        KEY=\"2009\"/>\n          <sear:FACET_VALUES VALUE=\"365768\" KEY=\"2006\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"400238\" KEY=\"2007\"/>\n          <sear:FACET_VALUES
-        VALUE=\"409796\" KEY=\"2004\"/>\n          <sear:FACET_VALUES VALUE=\"319342\"
-        KEY=\"2005\"/>\n          <sear:FACET_VALUES VALUE=\"178698\" KEY=\"2002\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"280769\" KEY=\"2003\"/>\n          <sear:FACET_VALUES
-        VALUE=\"7432\" KEY=\"1930\"/>\n          <sear:FACET_VALUES VALUE=\"10551\"
-        KEY=\"1970\"/>\n          <sear:FACET_VALUES VALUE=\"11164\" KEY=\"1971\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"11702\" KEY=\"1972\"/>\n          <sear:FACET_VALUES
-        VALUE=\"12327\" KEY=\"1973\"/>\n          <sear:FACET_VALUES VALUE=\"13795\"
-        KEY=\"1974\"/>\n          <sear:FACET_VALUES VALUE=\"15848\" KEY=\"1975\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"17391\" KEY=\"1976\"/>\n          <sear:FACET_VALUES
-        VALUE=\"19273\" KEY=\"1977\"/>\n          <sear:FACET_VALUES VALUE=\"358582\"
-        KEY=\"2012\"/>\n          <sear:FACET_VALUES VALUE=\"21611\" KEY=\"1978\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"470533\" KEY=\"2011\"/>\n          <sear:FACET_VALUES
-        VALUE=\"22864\" KEY=\"1979\"/>\n          <sear:FACET_VALUES VALUE=\"514960\"
-        KEY=\"2010\"/>\n          <sear:FACET_VALUES VALUE=\"12179\" KEY=\"1900\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"62246\" KEY=\"1990\"/>\n          <sear:FACET_VALUES
-        VALUE=\"9311\" KEY=\"1940\"/>\n          <sear:FACET_VALUES VALUE=\"21\" KEY=\"500\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"28054\" KEY=\"1982\"/>\n          <sear:FACET_VALUES
-        VALUE=\"30189\" KEY=\"1983\"/>\n          <sear:FACET_VALUES VALUE=\"25084\"
-        KEY=\"1980\"/>\n          <sear:FACET_VALUES VALUE=\"32\" KEY=\"1\"/>\n          <sear:FACET_VALUES
-        VALUE=\"26609\" KEY=\"1981\"/>\n          <sear:FACET_VALUES VALUE=\"41406\"
-        KEY=\"1986\"/>\n          <sear:FACET_VALUES VALUE=\"44290\" KEY=\"1987\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"33678\" KEY=\"1984\"/>\n          <sear:FACET_VALUES
-        VALUE=\"37847\" KEY=\"1985\"/>\n          <sear:FACET_VALUES VALUE=\"45838\"
-        KEY=\"1988\"/>\n          <sear:FACET_VALUES VALUE=\"57473\" KEY=\"1989\"/>\n
+        VALUE=\"293726\" KEY=\"2008\"/>\n          <sear:FACET_VALUES VALUE=\"338544\"
+        KEY=\"2009\"/>\n          <sear:FACET_VALUES VALUE=\"250403\" KEY=\"2006\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"289935\" KEY=\"2007\"/>\n          <sear:FACET_VALUES
+        VALUE=\"263934\" KEY=\"2004\"/>\n          <sear:FACET_VALUES VALUE=\"222860\"
+        KEY=\"2005\"/>\n          <sear:FACET_VALUES VALUE=\"141780\" KEY=\"2002\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"195369\" KEY=\"2003\"/>\n          <sear:FACET_VALUES
+        VALUE=\"7653\" KEY=\"1930\"/>\n          <sear:FACET_VALUES VALUE=\"11326\"
+        KEY=\"1970\"/>\n          <sear:FACET_VALUES VALUE=\"12011\" KEY=\"1971\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"12782\" KEY=\"1972\"/>\n          <sear:FACET_VALUES
+        VALUE=\"13502\" KEY=\"1973\"/>\n          <sear:FACET_VALUES VALUE=\"15182\"
+        KEY=\"1974\"/>\n          <sear:FACET_VALUES VALUE=\"17480\" KEY=\"1975\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"19438\" KEY=\"1976\"/>\n          <sear:FACET_VALUES
+        VALUE=\"21577\" KEY=\"1977\"/>\n          <sear:FACET_VALUES VALUE=\"400858\"
+        KEY=\"2012\"/>\n          <sear:FACET_VALUES VALUE=\"23893\" KEY=\"1978\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"376296\" KEY=\"2011\"/>\n          <sear:FACET_VALUES
+        VALUE=\"25338\" KEY=\"1979\"/>\n          <sear:FACET_VALUES VALUE=\"389593\"
+        KEY=\"2010\"/>\n          <sear:FACET_VALUES VALUE=\"103916\" KEY=\"2013\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"11450\" KEY=\"1900\"/>\n          <sear:FACET_VALUES
+        VALUE=\"63340\" KEY=\"1990\"/>\n          <sear:FACET_VALUES VALUE=\"9503\"
+        KEY=\"1940\"/>\n          <sear:FACET_VALUES VALUE=\"14\" KEY=\"500\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"30989\" KEY=\"1982\"/>\n          <sear:FACET_VALUES
+        VALUE=\"33115\" KEY=\"1983\"/>\n          <sear:FACET_VALUES VALUE=\"27658\"
+        KEY=\"1980\"/>\n          <sear:FACET_VALUES VALUE=\"182\" KEY=\"1\"/>\n          <sear:FACET_VALUES
+        VALUE=\"29276\" KEY=\"1981\"/>\n          <sear:FACET_VALUES VALUE=\"44579\"
+        KEY=\"1986\"/>\n          <sear:FACET_VALUES VALUE=\"47429\" KEY=\"1987\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"36396\" KEY=\"1984\"/>\n          <sear:FACET_VALUES
+        VALUE=\"41009\" KEY=\"1985\"/>\n          <sear:FACET_VALUES VALUE=\"48784\"
+        KEY=\"1988\"/>\n          <sear:FACET_VALUES VALUE=\"58303\" KEY=\"1989\"/>\n
         \         <sear:FACET_VALUES VALUE=\"1\" KEY=\"1000\"/>\n          <sear:FACET_VALUES
-        VALUE=\"5815\" KEY=\"1910\"/>\n          <sear:FACET_VALUES VALUE=\"12\" KEY=\"1600\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"5088\" KEY=\"1959\"/>\n          <sear:FACET_VALUES
-        VALUE=\"4875\" KEY=\"1958\"/>\n          <sear:FACET_VALUES VALUE=\"4832\"
-        KEY=\"1957\"/>\n          <sear:FACET_VALUES VALUE=\"4672\" KEY=\"1956\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"4577\" KEY=\"1955\"/>\n          <sear:FACET_VALUES
-        VALUE=\"4169\" KEY=\"1954\"/>\n          <sear:FACET_VALUES VALUE=\"4127\"
-        KEY=\"1953\"/>\n          <sear:FACET_VALUES VALUE=\"3951\" KEY=\"1952\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"4073\" KEY=\"1951\"/>\n          <sear:FACET_VALUES
-        VALUE=\"17597\" KEY=\"1950\"/>\n          <sear:FACET_VALUES VALUE=\"82857\"
-        KEY=\"1995\"/>\n          <sear:FACET_VALUES VALUE=\"88216\" KEY=\"1996\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"96811\" KEY=\"1997\"/>\n          <sear:FACET_VALUES
-        VALUE=\"103776\" KEY=\"1998\"/>\n          <sear:FACET_VALUES VALUE=\"65011\"
-        KEY=\"1991\"/>\n          <sear:FACET_VALUES VALUE=\"8\" KEY=\"1500\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"67344\" KEY=\"1992\"/>\n          <sear:FACET_VALUES
-        VALUE=\"71061\" KEY=\"1993\"/>\n          <sear:FACET_VALUES VALUE=\"75645\"
-        KEY=\"1994\"/>\n          <sear:FACET_VALUES VALUE=\"141\" KEY=\"1800\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"15\" KEY=\"1700\"/>\n          <sear:FACET_VALUES
-        VALUE=\"116087\" KEY=\"1999\"/>\n          <sear:FACET_VALUES VALUE=\"4357\"
-        KEY=\"1920\"/>\n          <sear:FACET_VALUES VALUE=\"9449\" KEY=\"1967\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"8309\" KEY=\"1966\"/>\n          <sear:FACET_VALUES
-        VALUE=\"10373\" KEY=\"1969\"/>\n          <sear:FACET_VALUES VALUE=\"10057\"
-        KEY=\"1968\"/>\n          <sear:FACET_VALUES VALUE=\"7920\" KEY=\"1963\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"6711\" KEY=\"1962\"/>\n          <sear:FACET_VALUES
-        VALUE=\"8357\" KEY=\"1965\"/>\n          <sear:FACET_VALUES VALUE=\"8500\"
-        KEY=\"1964\"/>\n          <sear:FACET_VALUES VALUE=\"6042\" KEY=\"1961\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"5735\" KEY=\"1960\"/>\n          <sear:FACET_VALUES
-        VALUE=\"158382\" KEY=\"2001\"/>\n          <sear:FACET_VALUES VALUE=\"139027\"
-        KEY=\"2000\"/>\n        </sear:FACET>\n        <sear:FACET COUNT=\"20\" NAME=\"domain\">\n
-        \         <sear:FACET_VALUES VALUE=\"28518\" KEY=\"Health &amp; General Sciences
-        (JSTOR)\"/>\n          <sear:FACET_VALUES VALUE=\"10326\" KEY=\"HathiTrust
-        Digital Library\"/>\n          <sear:FACET_VALUES VALUE=\"3287\" KEY=\"ebrary
-        Books\"/>\n          <sear:FACET_VALUES VALUE=\"60730\" KEY=\"Nature Publishing
-        Group (CrossRef)\"/>\n          <sear:FACET_VALUES VALUE=\"33186\" KEY=\"Life
-        Sciences (JSTOR)\"/>\n          <sear:FACET_VALUES VALUE=\"147832\" KEY=\"Wiley
-        Online Library\"/>\n          <sear:FACET_VALUES VALUE=\"1060381\" KEY=\"SciVerse
-        ScienceDirect (Elsevier)\"/>\n          <sear:FACET_VALUES VALUE=\"1030102\"
-        KEY=\"Health Reference Center Academic (Gale)\"/>\n          <sear:FACET_VALUES
-        VALUE=\"6055\" KEY=\"American Medical Association (CrossRef)\"/>\n          <sear:FACET_VALUES
-        VALUE=\"564\" KEY=\"Informit New Zealand Collection (RMIT)\"/>\n          <sear:FACET_VALUES
-        VALUE=\"4729\" KEY=\"American Association for the Advancement of Science (CrossRef)\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"30545\" KEY=\"Credo Reference\"/>\n          <sear:FACET_VALUES
-        VALUE=\"100\" KEY=\"Credo Reference Topic Pages\"/>\n          <sear:FACET_VALUES
-        VALUE=\"229\" KEY=\"Britannica Online Academic Edition\"/>\n          <sear:FACET_VALUES
-        VALUE=\"1599017\" KEY=\"MEDLINE (NLM)\"/>\n          <sear:FACET_VALUES VALUE=\"6819\"
-        KEY=\"Ebook Library (EBL) (Ebooks Corp.)\"/>\n          <sear:FACET_VALUES
-        VALUE=\"66154\" KEY=\"nature.com (Nature Publishing Group)\"/>\n          <sear:FACET_VALUES
-        VALUE=\"7412\" KEY=\"Informit Health (RMIT)\"/>\n          <sear:FACET_VALUES
-        VALUE=\"2375389\" KEY=\"OneFile (GALE)\"/>\n          <sear:FACET_VALUES VALUE=\"59\"
-        KEY=\"Gale Virtual Reference Library\"/>\n        </sear:FACET>\n        <sear:FACET
-        COUNT=\"18\" NAME=\"jtitle\">\n          <sear:FACET_VALUES VALUE=\"438\"
-        KEY=\"Complementary Therapies In Medicine\"/>\n          <sear:FACET_VALUES
-        VALUE=\"2068\" KEY=\"Bmj (clinical research ed.)\"/>\n          <sear:FACET_VALUES
-        VALUE=\"7397\" KEY=\"New England Journal Of Medicine\"/>\n          <sear:FACET_VALUES
-        VALUE=\"5175\" KEY=\"Jama: The Journal Of The American Medical Association\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"802\" KEY=\"U.S. News &amp; World Report\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"9912\" KEY=\"American Journal Of Surgery\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"4705\" KEY=\"Chest\"/>\n          <sear:FACET_VALUES
-        VALUE=\"9334\" KEY=\"Science\"/>\n          <sear:FACET_VALUES VALUE=\"88629\"
-        KEY=\"Cancer\"/>\n          <sear:FACET_VALUES VALUE=\"1672\" KEY=\"Bmj: British
-        Medical Journal\"/>\n          <sear:FACET_VALUES VALUE=\"7719\" KEY=\"Nature\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"303\" KEY=\"Australasian Epidemiologist\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"455\" KEY=\"Journal of Complementary
-        Medicine: CM, The\"/>\n          <sear:FACET_VALUES VALUE=\"12138\" KEY=\"British
-        Medical Journal\"/>\n          <sear:FACET_VALUES VALUE=\"536\" KEY=\"The
-        Nation (Thailand)\"/>\n          <sear:FACET_VALUES VALUE=\"48138\" KEY=\"Lancet\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"953\" KEY=\"American Journal Of Public
-        Health\"/>\n          <sear:FACET_VALUES VALUE=\"3253\" KEY=\"Science (new
-        york, n.y.)\"/>\n        </sear:FACET>\n      </sear:FACETLIST>\n      <sear:DOCSET
-        TOTAL_TIME=\"342\" LASTHIT=\"9\" FIRSTHIT=\"0\" TOTALHITS=\"6030775\" HIT_TIME=\"126\">\n
-        \       <sear:DOC LOCAL=\"false\" SEARCH_ENGINE_TYPE=\"Primo Central Search
-        Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\" NO=\"1\" RANK=\"1.0\" ID=\"74831403\">\n
-        \         <prim:PrimoNMBib xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
+        VALUE=\"6120\" KEY=\"1910\"/>\n          <sear:FACET_VALUES VALUE=\"5395\"
+        KEY=\"1959\"/>\n          <sear:FACET_VALUES VALUE=\"5258\" KEY=\"1958\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"5279\" KEY=\"1957\"/>\n          <sear:FACET_VALUES
+        VALUE=\"5138\" KEY=\"1956\"/>\n          <sear:FACET_VALUES VALUE=\"4950\"
+        KEY=\"1955\"/>\n          <sear:FACET_VALUES VALUE=\"4529\" KEY=\"1954\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"4454\" KEY=\"1953\"/>\n          <sear:FACET_VALUES
+        VALUE=\"4289\" KEY=\"1952\"/>\n          <sear:FACET_VALUES VALUE=\"4422\"
+        KEY=\"1951\"/>\n          <sear:FACET_VALUES VALUE=\"19400\" KEY=\"1950\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"86617\" KEY=\"1995\"/>\n          <sear:FACET_VALUES
+        VALUE=\"90434\" KEY=\"1996\"/>\n          <sear:FACET_VALUES VALUE=\"96194\"
+        KEY=\"1997\"/>\n          <sear:FACET_VALUES VALUE=\"99451\" KEY=\"1998\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"63937\" KEY=\"1991\"/>\n          <sear:FACET_VALUES
+        VALUE=\"1\" KEY=\"1500\"/>\n          <sear:FACET_VALUES VALUE=\"69117\" KEY=\"1992\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"74379\" KEY=\"1993\"/>\n          <sear:FACET_VALUES
+        VALUE=\"79273\" KEY=\"1994\"/>\n          <sear:FACET_VALUES VALUE=\"91\"
+        KEY=\"1800\"/>\n          <sear:FACET_VALUES VALUE=\"14\" KEY=\"1700\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"108882\" KEY=\"1999\"/>\n          <sear:FACET_VALUES
+        VALUE=\"4650\" KEY=\"1920\"/>\n          <sear:FACET_VALUES VALUE=\"10115\"
+        KEY=\"1967\"/>\n          <sear:FACET_VALUES VALUE=\"8994\" KEY=\"1966\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"11220\" KEY=\"1969\"/>\n          <sear:FACET_VALUES
+        VALUE=\"10881\" KEY=\"1968\"/>\n          <sear:FACET_VALUES VALUE=\"8046\"
+        KEY=\"1963\"/>\n          <sear:FACET_VALUES VALUE=\"6786\" KEY=\"1962\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"8760\" KEY=\"1965\"/>\n          <sear:FACET_VALUES
+        VALUE=\"8669\" KEY=\"1964\"/>\n          <sear:FACET_VALUES VALUE=\"6162\"
+        KEY=\"1961\"/>\n          <sear:FACET_VALUES VALUE=\"6023\" KEY=\"1960\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"132206\" KEY=\"2001\"/>\n          <sear:FACET_VALUES
+        VALUE=\"122739\" KEY=\"2000\"/>\n        </sear:FACET>\n        <sear:FACET
+        COUNT=\"11\" NAME=\"domain\">\n          <sear:FACET_VALUES VALUE=\"54893\"
+        KEY=\"Health &amp; General Sciences (JSTOR)\"/>\n          <sear:FACET_VALUES
+        VALUE=\"127192\" KEY=\"Nature Publishing Group (CrossRef)\"/>\n          <sear:FACET_VALUES
+        VALUE=\"2693936\" KEY=\"MEDLINE (NLM)\"/>\n          <sear:FACET_VALUES VALUE=\"63427\"
+        KEY=\"Life Sciences (JSTOR)\"/>\n          <sear:FACET_VALUES VALUE=\"135577\"
+        KEY=\"nature.com (Nature Publishing Group)\"/>\n          <sear:FACET_VALUES
+        VALUE=\"8479\" KEY=\"Informit Health (RMIT)\"/>\n          <sear:FACET_VALUES
+        VALUE=\"307203\" KEY=\"Wiley Online Library\"/>\n          <sear:FACET_VALUES
+        VALUE=\"1348943\" KEY=\"SciVerse ScienceDirect (Elsevier)\"/>\n          <sear:FACET_VALUES
+        VALUE=\"2200975\" KEY=\"OneFile (GALE)\"/>\n          <sear:FACET_VALUES VALUE=\"14534\"
+        KEY=\"American Medical Association (CrossRef)\"/>\n          <sear:FACET_VALUES
+        VALUE=\"7795\" KEY=\"American Association for the Advancement of Science (CrossRef)\"/>\n
+        \       </sear:FACET>\n        <sear:FACET COUNT=\"18\" NAME=\"jtitle\">\n
+        \         <sear:FACET_VALUES VALUE=\"509\" KEY=\"Complementary Therapies In
+        Medicine\"/>\n          <sear:FACET_VALUES VALUE=\"3885\" KEY=\"Bmj (clinical
+        research ed.)\"/>\n          <sear:FACET_VALUES VALUE=\"9428\" KEY=\"Jama:
+        The Journal Of The American Medical Association\"/>\n          <sear:FACET_VALUES
+        VALUE=\"13323\" KEY=\"American Journal of Surgery\"/>\n          <sear:FACET_VALUES
+        VALUE=\"1604\" KEY=\"Nature Reviews Drug Discovery\"/>\n          <sear:FACET_VALUES
+        VALUE=\"6553\" KEY=\"Chest\"/>\n          <sear:FACET_VALUES VALUE=\"10392\"
+        KEY=\"Science\"/>\n          <sear:FACET_VALUES VALUE=\"139114\" KEY=\"Cancer\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"13803\" KEY=\"New England journal of
+        medicine\"/>\n          <sear:FACET_VALUES VALUE=\"3172\" KEY=\"Bmj: British
+        Medical Journal\"/>\n          <sear:FACET_VALUES VALUE=\"9928\" KEY=\"Nature\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"533\" KEY=\"Scientific American\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"4267\" KEY=\"Chest Journal\"/>\n          <sear:FACET_VALUES
+        VALUE=\"12692\" KEY=\"British Medical Journal\"/>\n          <sear:FACET_VALUES
+        VALUE=\"820\" KEY=\"Iarc Scientific Publications\"/>\n          <sear:FACET_VALUES
+        VALUE=\"53574\" KEY=\"Lancet\"/>\n          <sear:FACET_VALUES VALUE=\"1576\"
+        KEY=\"American Journal Of Public Health\"/>\n          <sear:FACET_VALUES
+        VALUE=\"7239\" KEY=\"Science (new york, n.y.)\"/>\n        </sear:FACET>\n
+        \     </sear:FACETLIST>\n      <sear:DOCSET TOTAL_TIME=\"319\" LASTHIT=\"10\"
+        FIRSTHIT=\"1\" TOTALHITS=\"5063266\" HIT_TIME=\"68\">\n        <sear:DOC LOCAL=\"false\"
+        SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
+        NO=\"1\" RANK=\"1.0\" ID=\"410168103\">\n          <prim:PrimoNMBib xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
+        xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n            <prim:record>\n
+        \             <prim:control>\n                <prim:sourcerecordid>188005462</prim:sourcerecordid>\n
+        \               <prim:sourceid>gale_ofa</prim:sourceid>\n                <prim:recordid>TN_gale_ofa188005462</prim:recordid>\n
+        \               <prim:sourceformat>XML</prim:sourceformat>\n                <prim:sourcesystem>Other</prim:sourcesystem>\n
+        \             </prim:control>\n              <prim:display>\n                <prim:type>article</prim:type>\n
+        \               <prim:title>&lt;span class=\"searchword\">Cancer&lt;/span></prim:title>\n
+        \               <prim:creator>Pulverer, Bernd ; Anson, Lesley ; Surridge,
+        Chris ; Allen, Liz</prim:creator>\n                <prim:ispartof>Nature,
+        May 17, 2001, Vol.411(6835), p.335(1)</prim:ispartof>\n                <prim:identifier>&lt;b>ISSN:
+        &lt;/b>0028-0836</prim:identifier>\n                <prim:language>English</prim:language>\n
+        \               <prim:source>Cengage Learning, Inc.</prim:source>\n                <prim:lds50>peer_reviewed</prim:lds50>\n
+        \               <prim:version>4</prim:version>\n                <prim:snippet/>\n
+        \             </prim:display>\n              <prim:links>\n                <prim:openurl>$$Topenurl_article</prim:openurl>\n
+        \               <prim:openurlfulltext>$$Topenurlfull_article</prim:openurlfulltext>\n
+        \             </prim:links>\n              <prim:search>\n                <prim:scope>gale_onefileg</prim:scope>\n
+        \               <prim:scope>gale_onefilea</prim:scope>\n                <prim:creatorcontrib>Pulverer,
+        Bernd</prim:creatorcontrib>\n                <prim:creatorcontrib>Bernd Pulverer;
+        Lesley Anson; Chris Surridge; Liz Allen</prim:creatorcontrib>\n                <prim:creatorcontrib>Anson,
+        Lesley</prim:creatorcontrib>\n                <prim:creatorcontrib>Surridge,
+        Chris</prim:creatorcontrib>\n                <prim:creatorcontrib>Allen, Liz</prim:creatorcontrib>\n
+        \               <prim:title>&lt;span class=\"searchword\">Cancer&lt;/span>.</prim:title>\n
+        \               <prim:general>English</prim:general>\n                <prim:general>Nature
+        Publishing Group</prim:general>\n                <prim:general>Cengage Learning,
+        Inc.</prim:general>\n                <prim:sourceid>gale_ofa</prim:sourceid>\n
+        \               <prim:recordid>gale_ofa188005462</prim:recordid>\n                <prim:issn>0028-0836</prim:issn>\n
+        \               <prim:issn>00280836</prim:issn>\n                <prim:rsrctype>article</prim:rsrctype>\n
+        \               <prim:creationdate>2001</prim:creationdate>\n                <prim:recordtype>article</prim:recordtype>\n
+        \               <prim:addtitle>Nature</prim:addtitle>\n                <prim:searchscope>OneFile</prim:searchscope>\n
+        \               <prim:scope>OneFile</prim:scope>\n              </prim:search>\n
+        \             <prim:sort>\n                <prim:title>Cancer.</prim:title>\n
+        \               <prim:author>Pulverer, Bernd ; Anson, Lesley ; Surridge, Chris
+        ; Allen, Liz</prim:author>\n                <prim:creationdate>20010517</prim:creationdate>\n
+        \             </prim:sort>\n              <prim:facets>\n                <prim:frbrgroupid>7977124586984150303</prim:frbrgroupid>\n
+        \               <prim:frbrtype>5</prim:frbrtype>\n                <prim:language>eng</prim:language>\n
+        \               <prim:creationdate>2001</prim:creationdate>\n                <prim:collection>OneFile
+        (GALE)</prim:collection>\n                <prim:prefilter>articles</prim:prefilter>\n
+        \               <prim:rsrctype>articles</prim:rsrctype>\n                <prim:creatorcontrib>Pulverer,
+        Bernd</prim:creatorcontrib>\n                <prim:creatorcontrib>Anson, Lesley</prim:creatorcontrib>\n
+        \               <prim:creatorcontrib>Surridge, Chris</prim:creatorcontrib>\n
+        \               <prim:creatorcontrib>Allen, Liz</prim:creatorcontrib>\n                <prim:jtitle>Nature</prim:jtitle>\n
+        \               <prim:toplevel>peer_reviewed</prim:toplevel>\n              </prim:facets>\n
+        \             <prim:frbr>\n                <prim:t>2</prim:t>\n                <prim:k1>2001</prim:k1>\n
+        \               <prim:k2>00280836</prim:k2>\n                <prim:k4>411</prim:k4>\n
+        \               <prim:k5>6835</prim:k5>\n                <prim:k6>335</prim:k6>\n
+        \               <prim:k7>nature</prim:k7>\n                <prim:k8>cancer</prim:k8>\n
+        \               <prim:k9>cancer</prim:k9>\n                <prim:k15>berndpulverer</prim:k15>\n
+        \               <prim:k16>pulvererbernd</prim:k16>\n              </prim:frbr>\n
+        \             <prim:delivery>\n                <prim:delcategory>Remote Search
+        Resource</prim:delcategory>\n                <prim:fulltext>fulltext</prim:fulltext>\n
+        \             </prim:delivery>\n              <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
+        \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>aggregator</prim:pcg_type>\n
+        \             </prim:ranking>\n              <prim:addata>\n                <prim:au>Pulverer,
+        Bernd</prim:au>\n                <prim:au>Anson, Lesley</prim:au>\n                <prim:au>Surridge,
+        Chris</prim:au>\n                <prim:au>Allen, Liz</prim:au>\n                <prim:atitle>Cancer.</prim:atitle>\n
+        \               <prim:jtitle>Nature</prim:jtitle>\n                <prim:date>20010517</prim:date>\n
+        \               <prim:risdate>20010517</prim:risdate>\n                <prim:volume>411</prim:volume>\n
+        \               <prim:issue>6835</prim:issue>\n                <prim:spage>335</prim:spage>\n
+        \               <prim:issn>0028-0836</prim:issn>\n                <prim:genre>article</prim:genre>\n
+        \               <prim:ristype>JOUR</prim:ristype>\n                <prim:pub>Nature
+        Publishing Group</prim:pub>\n                <prim:lad01>gale_ofa</prim:lad01>\n
+        \             </prim:addata>\n            </prim:record>\n          </prim:PrimoNMBib>\n
+        \         <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A48IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A48IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A49IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A49IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A48IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=Nature&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Pulverer,%20Bernd&rft.aucorp=&rft.date=20010517&rft.volume=411&rft.issue=6835&rft.part=&rft.quarter=&rft.ssn=&rft.spage=335&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0028-0836&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>188005462</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A48IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=Nature&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Pulverer,%20Bernd&rft.aucorp=&rft.date=20010517&rft.volume=411&rft.issue=6835&rft.part=&rft.quarter=&rft.ssn=&rft.spage=335&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0028-0836&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>188005462</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A49IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=Nature&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Pulverer,%20Bernd&rft.aucorp=&rft.date=20010517&rft.volume=411&rft.issue=6835&rft.part=&rft.quarter=&rft.ssn=&rft.spage=335&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0028-0836&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>188005462</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A49IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=Nature&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Pulverer,%20Bernd&rft.aucorp=&rft.date=20010517&rft.volume=411&rft.issue=6835&rft.part=&rft.quarter=&rft.ssn=&rft.spage=335&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0028-0836&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>188005462</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n        </sear:DOC>\n        <sear:DOC LOCAL=\"false\"
+        SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
+        NO=\"2\" RANK=\"0.5732081\" ID=\"24324986\">\n          <prim:PrimoNMBib xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
         xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n            <prim:record>\n
         \             <prim:control>\n                <prim:sourcerecordid>71838595</prim:sourcerecordid>\n
-        \               <prim:sourceid>gale_hrca</prim:sourceid>\n                <prim:recordid>TN_gale_hrca71838595</prim:recordid>\n
+        \               <prim:sourceid>gale_ofa</prim:sourceid>\n                <prim:recordid>TN_gale_ofa71838595</prim:recordid>\n
         \               <prim:sourceformat>XML</prim:sourceformat>\n                <prim:sourcesystem>Other</prim:sourcesystem>\n
         \             </prim:control>\n              <prim:display>\n                <prim:type>article</prim:type>\n
         \               <prim:title>&lt;span class=\"searchword\">Cancer&lt;/span></prim:title>\n
@@ -232,35 +295,37 @@ http_interactions:
         &lt;/b>0098-7484</prim:identifier>\n                <prim:subject>&lt;span
         class=\"searchword\">Cancer&lt;/span> -- Bibliography</prim:subject>\n                <prim:source>Cengage
         Learning, Inc.</prim:source>\n                <prim:lds50>peer_reviewed</prim:lds50>\n
-        \               <prim:version>2</prim:version>\n                <prim:snippet/>\n
+        \               <prim:version>2</prim:version>\n                <prim:snippetfield>subject</prim:snippetfield>\n
+        \               <prim:snippet>&lt;span class=\"searchword\">Cancer&lt;/span>--Bibliography</prim:snippet>\n
         \             </prim:display>\n              <prim:links>\n                <prim:openurl>$$Topenurl_article</prim:openurl>\n
         \               <prim:openurlfulltext>$$Topenurlfull_article</prim:openurlfulltext>\n
-        \             </prim:links>\n              <prim:search>\n                <prim:title>&lt;span
+        \             </prim:links>\n              <prim:search>\n                <prim:scope>gale_onefileg</prim:scope>\n
+        \               <prim:scope>gale_onefilea</prim:scope>\n                <prim:title>&lt;span
         class=\"searchword\">Cancer&lt;/span>.</prim:title>\n                <prim:subject>Cancer--Bibliography</prim:subject>\n
         \               <prim:general>American Medical Association</prim:general>\n
-        \               <prim:general>Cengage Learning, Inc.</prim:general>\n                <prim:sourceid>gale_hrca</prim:sourceid>\n
-        \               <prim:recordid>gale_hrca71838595</prim:recordid>\n                <prim:issn>0098-7484</prim:issn>\n
+        \               <prim:general>Cengage Learning, Inc.</prim:general>\n                <prim:sourceid>gale_ofa</prim:sourceid>\n
+        \               <prim:recordid>gale_ofa71838595</prim:recordid>\n                <prim:issn>0098-7484</prim:issn>\n
         \               <prim:issn>00987484</prim:issn>\n                <prim:rsrctype>article</prim:rsrctype>\n
         \               <prim:creationdate>2001</prim:creationdate>\n                <prim:recordtype>article</prim:recordtype>\n
         \               <prim:addtitle>JAMA, The Journal of the American Medical Association</prim:addtitle>\n
-        \               <prim:searchscope>gale_hrca</prim:searchscope>\n                <prim:scope>gale_hrca</prim:scope>\n
+        \               <prim:searchscope>OneFile</prim:searchscope>\n                <prim:scope>OneFile</prim:scope>\n
         \             </prim:search>\n              <prim:sort>\n                <prim:title>Cancer.</prim:title>\n
         \               <prim:creationdate>20010314</prim:creationdate>\n              </prim:sort>\n
-        \             <prim:facets>\n                <prim:creationdate>2001</prim:creationdate>\n
-        \               <prim:topic>Cancer–Bibliography</prim:topic>\n                <prim:collection>Health
-        Reference Center Academic (Gale)</prim:collection>\n                <prim:prefilter>articles</prim:prefilter>\n
+        \             <prim:facets>\n                <prim:frbrgroupid>6042759724874213318</prim:frbrgroupid>\n
+        \               <prim:frbrtype>5</prim:frbrtype>\n                <prim:creationdate>2001</prim:creationdate>\n
+        \               <prim:topic>Cancer–Bibliography</prim:topic>\n                <prim:collection>OneFile
+        (GALE)</prim:collection>\n                <prim:prefilter>articles</prim:prefilter>\n
         \               <prim:rsrctype>articles</prim:rsrctype>\n                <prim:jtitle>JAMA,
         The Journal of the American Medical Association</prim:jtitle>\n                <prim:toplevel>peer_reviewed</prim:toplevel>\n
-        \               <prim:frbrgroupid>6042759724874213318</prim:frbrgroupid>\n
-        \               <prim:frbrtype>5</prim:frbrtype>\n              </prim:facets>\n
-        \             <prim:frbr>\n                <prim:t>2</prim:t>\n                <prim:k1>2001</prim:k1>\n
-        \               <prim:k2>00987484</prim:k2>\n                <prim:k4>285</prim:k4>\n
-        \               <prim:k5>10</prim:k5>\n                <prim:k6>1363</prim:k6>\n
-        \               <prim:k7>jama the journal of the american medical association</prim:k7>\n
-        \               <prim:k8>cancer</prim:k8>\n                <prim:k9>cancer</prim:k9>\n
-        \             </prim:frbr>\n              <prim:delivery>\n                <prim:delcategory>Remote
-        Search Resource</prim:delcategory>\n                <prim:fulltext>fulltext</prim:fulltext>\n
-        \             </prim:delivery>\n              <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
+        \             </prim:facets>\n              <prim:frbr>\n                <prim:t>2</prim:t>\n
+        \               <prim:k1>2001</prim:k1>\n                <prim:k2>00987484</prim:k2>\n
+        \               <prim:k4>285</prim:k4>\n                <prim:k5>10</prim:k5>\n
+        \               <prim:k6>1363</prim:k6>\n                <prim:k7>jama the
+        journal of the american medical association</prim:k7>\n                <prim:k8>cancer</prim:k8>\n
+        \               <prim:k9>cancer</prim:k9>\n              </prim:frbr>\n              <prim:delivery>\n
+        \               <prim:delcategory>Remote Search Resource</prim:delcategory>\n
+        \               <prim:fulltext>fulltext</prim:fulltext>\n              </prim:delivery>\n
+        \             <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
         \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>aggregator</prim:pcg_type>\n
         \             </prim:ranking>\n              <prim:addata>\n                <prim:atitle>Cancer.</prim:atitle>\n
         \               <prim:jtitle>JAMA, The Journal of the American Medical Association</prim:jtitle>\n
@@ -268,17 +333,21 @@ http_interactions:
         \               <prim:volume>285</prim:volume>\n                <prim:issue>10</prim:issue>\n
         \               <prim:spage>1363</prim:spage>\n                <prim:issn>0098-7484</prim:issn>\n
         \               <prim:genre>article</prim:genre>\n                <prim:ristype>JOUR</prim:ristype>\n
-        \               <prim:pub>American Medical Association</prim:pub>\n                <prim:lad01>gale_hrca</prim:lad01>\n
+        \               <prim:pub>American Medical Association</prim:pub>\n                <prim:lad01>gale_ofa</prim:lad01>\n
         \             </prim:addata>\n            </prim:record>\n          </prim:PrimoNMBib>\n
-        \         <sear:GETIT GetIt2=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-09-18T23%3A42%3A08IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=20010314&amp;rft.volume=285&amp;rft.issue=10&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=1363&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0098-7484&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.eisbn=&amp;rft_dat=&lt;gale_hrca>71838595&lt;/gale_hrca>&amp;rft_id=info:oai/>\"
-        GetIt1=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-09-18T23%3A42%3A08IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=20010314&amp;rft.volume=285&amp;rft.issue=10&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=1363&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0098-7484&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft.eisbn=&amp;rft_dat=&lt;gale_hrca>71838595&lt;/gale_hrca>&amp;rft_id=info:oai/>\"
-        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-09-18T23%3A42%3A08IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010314&rft.volume=285&rft.issue=10&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1363&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.eisbn=&rft_dat=<gale_hrca>71838595</gale_hrca>&rft_id=info:oai/>]]></sear:openurl>\n
-        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-09-18T23%3A42%3A08IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010314&rft.volume=285&rft.issue=10&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1363&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft.eisbn=&rft_dat=<gale_hrca>71838595</gale_hrca>&rft_id=info:oai/>]]></sear:openurlfulltext>\n
+        \         <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A48IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A48IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A49IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A49IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A48IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010314&rft.volume=285&rft.issue=10&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1363&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>71838595</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A48IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010314&rft.volume=285&rft.issue=10&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1363&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>71838595</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A49IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010314&rft.volume=285&rft.issue=10&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1363&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>71838595</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A49IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010314&rft.volume=285&rft.issue=10&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1363&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>71838595</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
         \         </sear:LINKS>\n        </sear:DOC>\n        <sear:DOC LOCAL=\"false\"
         SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
-        NO=\"2\" RANK=\"1.0\" ID=\"85759608\">\n          <prim:PrimoNMBib xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
-        xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n            <prim:record>\n
-        \             <prim:control>\n                <prim:sourcerecordid>72070243</prim:sourcerecordid>\n
+        NO=\"3\" RANK=\"0.5732081\" ID=\"46325641\">\n          <prim:PrimoNMBib xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
+        xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n
+        \           <prim:record>\n              <prim:control>\n                <prim:sourcerecordid>72070243</prim:sourcerecordid>\n
         \               <prim:sourceid>gale_ofa</prim:sourceid>\n                <prim:recordid>TN_gale_ofa72070243</prim:recordid>\n
         \               <prim:sourceformat>XML</prim:sourceformat>\n                <prim:sourcesystem>Other</prim:sourcesystem>\n
         \             </prim:control>\n              <prim:display>\n                <prim:type>article</prim:type>\n
@@ -288,10 +357,12 @@ http_interactions:
         &lt;/b>0098-7484</prim:identifier>\n                <prim:subject>&lt;span
         class=\"searchword\">Cancer&lt;/span> -- Bibliography</prim:subject>\n                <prim:source>Cengage
         Learning, Inc.</prim:source>\n                <prim:lds50>peer_reviewed</prim:lds50>\n
-        \               <prim:version>2</prim:version>\n                <prim:snippet/>\n
+        \               <prim:version>2</prim:version>\n                <prim:snippetfield>subject</prim:snippetfield>\n
+        \               <prim:snippet>&lt;span class=\"searchword\">Cancer&lt;/span>--Bibliography</prim:snippet>\n
         \             </prim:display>\n              <prim:links>\n                <prim:openurl>$$Topenurl_article</prim:openurl>\n
         \               <prim:openurlfulltext>$$Topenurlfull_article</prim:openurlfulltext>\n
-        \             </prim:links>\n              <prim:search>\n                <prim:title>&lt;span
+        \             </prim:links>\n              <prim:search>\n                <prim:scope>gale_onefileg</prim:scope>\n
+        \               <prim:scope>gale_onefilea</prim:scope>\n                <prim:title>&lt;span
         class=\"searchword\">Cancer&lt;/span>.</prim:title>\n                <prim:subject>Cancer--Bibliography</prim:subject>\n
         \               <prim:general>American Medical Association</prim:general>\n
         \               <prim:general>Cengage Learning, Inc.</prim:general>\n                <prim:sourceid>gale_ofa</prim:sourceid>\n
@@ -302,21 +373,21 @@ http_interactions:
         \               <prim:searchscope>OneFile</prim:searchscope>\n                <prim:scope>OneFile</prim:scope>\n
         \             </prim:search>\n              <prim:sort>\n                <prim:title>Cancer.</prim:title>\n
         \               <prim:creationdate>20010321</prim:creationdate>\n              </prim:sort>\n
-        \             <prim:facets>\n                <prim:creationdate>2001</prim:creationdate>\n
+        \             <prim:facets>\n                <prim:frbrgroupid>6042759724874213319</prim:frbrgroupid>\n
+        \               <prim:frbrtype>5</prim:frbrtype>\n                <prim:creationdate>2001</prim:creationdate>\n
         \               <prim:topic>Cancer–Bibliography</prim:topic>\n                <prim:collection>OneFile
         (GALE)</prim:collection>\n                <prim:prefilter>articles</prim:prefilter>\n
         \               <prim:rsrctype>articles</prim:rsrctype>\n                <prim:jtitle>JAMA,
         The Journal of the American Medical Association</prim:jtitle>\n                <prim:toplevel>peer_reviewed</prim:toplevel>\n
-        \               <prim:frbrgroupid>6042759724874213319</prim:frbrgroupid>\n
-        \               <prim:frbrtype>5</prim:frbrtype>\n              </prim:facets>\n
-        \             <prim:frbr>\n                <prim:t>2</prim:t>\n                <prim:k1>2001</prim:k1>\n
-        \               <prim:k2>00987484</prim:k2>\n                <prim:k4>285</prim:k4>\n
-        \               <prim:k5>11</prim:k5>\n                <prim:k6>1517</prim:k6>\n
-        \               <prim:k7>jama the journal of the american medical association</prim:k7>\n
-        \               <prim:k8>cancer</prim:k8>\n                <prim:k9>cancer</prim:k9>\n
-        \             </prim:frbr>\n              <prim:delivery>\n                <prim:delcategory>Remote
-        Search Resource</prim:delcategory>\n                <prim:fulltext>fulltext</prim:fulltext>\n
-        \             </prim:delivery>\n              <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
+        \             </prim:facets>\n              <prim:frbr>\n                <prim:t>2</prim:t>\n
+        \               <prim:k1>2001</prim:k1>\n                <prim:k2>00987484</prim:k2>\n
+        \               <prim:k4>285</prim:k4>\n                <prim:k5>11</prim:k5>\n
+        \               <prim:k6>1517</prim:k6>\n                <prim:k7>jama the
+        journal of the american medical association</prim:k7>\n                <prim:k8>cancer</prim:k8>\n
+        \               <prim:k9>cancer</prim:k9>\n              </prim:frbr>\n              <prim:delivery>\n
+        \               <prim:delcategory>Remote Search Resource</prim:delcategory>\n
+        \               <prim:fulltext>fulltext</prim:fulltext>\n              </prim:delivery>\n
+        \             <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
         \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>aggregator</prim:pcg_type>\n
         \             </prim:ranking>\n              <prim:addata>\n                <prim:atitle>Cancer.</prim:atitle>\n
         \               <prim:jtitle>JAMA, The Journal of the American Medical Association</prim:jtitle>\n
@@ -326,13 +397,17 @@ http_interactions:
         \               <prim:genre>article</prim:genre>\n                <prim:ristype>JOUR</prim:ristype>\n
         \               <prim:pub>American Medical Association</prim:pub>\n                <prim:lad01>gale_ofa</prim:lad01>\n
         \             </prim:addata>\n            </prim:record>\n          </prim:PrimoNMBib>\n
-        \         <sear:GETIT GetIt2=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-09-18T23%3A42%3A08IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=20010314&amp;rft.volume=285&amp;rft.issue=10&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=1363&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0098-7484&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.eisbn=&amp;rft_dat=&lt;gale_hrca>71838595&lt;/gale_hrca>&amp;rft_id=info:oai/>\"
-        GetIt1=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-09-18T23%3A42%3A08IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=20010314&amp;rft.volume=285&amp;rft.issue=10&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=1363&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0098-7484&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft.eisbn=&amp;rft_dat=&lt;gale_hrca>71838595&lt;/gale_hrca>&amp;rft_id=info:oai/>\"
-        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-09-18T23%3A42%3A08IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010321&rft.volume=285&rft.issue=11&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1517&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.eisbn=&rft_dat=<gale_ofa>72070243</gale_ofa>&rft_id=info:oai/>]]></sear:openurl>\n
-        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-09-18T23%3A42%3A08IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010321&rft.volume=285&rft.issue=11&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1517&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft.eisbn=&rft_dat=<gale_ofa>72070243</gale_ofa>&rft_id=info:oai/>]]></sear:openurlfulltext>\n
+        \         <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A48IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A48IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A49IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A49IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A48IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010321&rft.volume=285&rft.issue=11&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1517&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>72070243</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A48IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010321&rft.volume=285&rft.issue=11&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1517&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>72070243</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A49IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010321&rft.volume=285&rft.issue=11&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1517&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>72070243</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A49IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010321&rft.volume=285&rft.issue=11&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1517&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>72070243</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
         \         </sear:LINKS>\n        </sear:DOC>\n        <sear:DOC LOCAL=\"false\"
         SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
-        NO=\"3\" RANK=\"1.0\" ID=\"107612925\">\n          <prim:PrimoNMBib xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
+        NO=\"4\" RANK=\"0.5732081\" ID=\"66463816\">\n          <prim:PrimoNMBib xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
         xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n
         \           <prim:record>\n              <prim:control>\n                <prim:sourcerecordid>72986125</prim:sourcerecordid>\n
         \               <prim:sourceid>gale_ofa</prim:sourceid>\n                <prim:recordid>TN_gale_ofa72986125</prim:recordid>\n
@@ -344,10 +419,12 @@ http_interactions:
         &lt;/b>0098-7484</prim:identifier>\n                <prim:subject>&lt;span
         class=\"searchword\">Cancer&lt;/span> -- Bibliography</prim:subject>\n                <prim:source>Cengage
         Learning, Inc.</prim:source>\n                <prim:lds50>peer_reviewed</prim:lds50>\n
-        \               <prim:version>2</prim:version>\n                <prim:snippet/>\n
+        \               <prim:version>2</prim:version>\n                <prim:snippetfield>subject</prim:snippetfield>\n
+        \               <prim:snippet>&lt;span class=\"searchword\">Cancer&lt;/span>--Bibliography</prim:snippet>\n
         \             </prim:display>\n              <prim:links>\n                <prim:openurl>$$Topenurl_article</prim:openurl>\n
         \               <prim:openurlfulltext>$$Topenurlfull_article</prim:openurlfulltext>\n
-        \             </prim:links>\n              <prim:search>\n                <prim:title>&lt;span
+        \             </prim:links>\n              <prim:search>\n                <prim:scope>gale_onefilea</prim:scope>\n
+        \               <prim:scope>gale_onefileg</prim:scope>\n                <prim:title>&lt;span
         class=\"searchword\">Cancer&lt;/span>.</prim:title>\n                <prim:subject>Cancer--Bibliography</prim:subject>\n
         \               <prim:general>American Medical Association</prim:general>\n
         \               <prim:general>Cengage Learning, Inc.</prim:general>\n                <prim:sourceid>gale_ofa</prim:sourceid>\n
@@ -358,21 +435,21 @@ http_interactions:
         \               <prim:searchscope>OneFile</prim:searchscope>\n                <prim:scope>OneFile</prim:scope>\n
         \             </prim:search>\n              <prim:sort>\n                <prim:title>Cancer.</prim:title>\n
         \               <prim:creationdate>20010404</prim:creationdate>\n              </prim:sort>\n
-        \             <prim:facets>\n                <prim:creationdate>2001</prim:creationdate>\n
+        \             <prim:facets>\n                <prim:frbrgroupid>6042759724874213321</prim:frbrgroupid>\n
+        \               <prim:frbrtype>5</prim:frbrtype>\n                <prim:creationdate>2001</prim:creationdate>\n
         \               <prim:topic>Cancer–Bibliography</prim:topic>\n                <prim:collection>OneFile
         (GALE)</prim:collection>\n                <prim:prefilter>articles</prim:prefilter>\n
         \               <prim:rsrctype>articles</prim:rsrctype>\n                <prim:jtitle>JAMA,
         The Journal of the American Medical Association</prim:jtitle>\n                <prim:toplevel>peer_reviewed</prim:toplevel>\n
-        \               <prim:frbrgroupid>6042759724874213321</prim:frbrgroupid>\n
-        \               <prim:frbrtype>5</prim:frbrtype>\n              </prim:facets>\n
-        \             <prim:frbr>\n                <prim:t>2</prim:t>\n                <prim:k1>2001</prim:k1>\n
-        \               <prim:k2>00987484</prim:k2>\n                <prim:k4>285</prim:k4>\n
-        \               <prim:k5>13</prim:k5>\n                <prim:k6>1774</prim:k6>\n
-        \               <prim:k7>jama the journal of the american medical association</prim:k7>\n
-        \               <prim:k8>cancer</prim:k8>\n                <prim:k9>cancer</prim:k9>\n
-        \             </prim:frbr>\n              <prim:delivery>\n                <prim:delcategory>Remote
-        Search Resource</prim:delcategory>\n                <prim:fulltext>fulltext</prim:fulltext>\n
-        \             </prim:delivery>\n              <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
+        \             </prim:facets>\n              <prim:frbr>\n                <prim:t>2</prim:t>\n
+        \               <prim:k1>2001</prim:k1>\n                <prim:k2>00987484</prim:k2>\n
+        \               <prim:k4>285</prim:k4>\n                <prim:k5>13</prim:k5>\n
+        \               <prim:k6>1774</prim:k6>\n                <prim:k7>jama the
+        journal of the american medical association</prim:k7>\n                <prim:k8>cancer</prim:k8>\n
+        \               <prim:k9>cancer</prim:k9>\n              </prim:frbr>\n              <prim:delivery>\n
+        \               <prim:delcategory>Remote Search Resource</prim:delcategory>\n
+        \               <prim:fulltext>fulltext</prim:fulltext>\n              </prim:delivery>\n
+        \             <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
         \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>aggregator</prim:pcg_type>\n
         \             </prim:ranking>\n              <prim:addata>\n                <prim:atitle>Cancer.</prim:atitle>\n
         \               <prim:jtitle>JAMA, The Journal of the American Medical Association</prim:jtitle>\n
@@ -382,15 +459,20 @@ http_interactions:
         \               <prim:genre>article</prim:genre>\n                <prim:ristype>JOUR</prim:ristype>\n
         \               <prim:pub>American Medical Association</prim:pub>\n                <prim:lad01>gale_ofa</prim:lad01>\n
         \             </prim:addata>\n            </prim:record>\n          </prim:PrimoNMBib>\n
-        \         <sear:GETIT GetIt2=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-09-18T23%3A42%3A08IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=20010314&amp;rft.volume=285&amp;rft.issue=10&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=1363&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0098-7484&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.eisbn=&amp;rft_dat=&lt;gale_hrca>71838595&lt;/gale_hrca>&amp;rft_id=info:oai/>\"
-        GetIt1=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-09-18T23%3A42%3A08IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=20010314&amp;rft.volume=285&amp;rft.issue=10&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=1363&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0098-7484&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft.eisbn=&amp;rft_dat=&lt;gale_hrca>71838595&lt;/gale_hrca>&amp;rft_id=info:oai/>\"
-        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-09-18T23%3A42%3A08IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010404&rft.volume=285&rft.issue=13&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1774&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.eisbn=&rft_dat=<gale_ofa>72986125</gale_ofa>&rft_id=info:oai/>]]></sear:openurl>\n
-        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-09-18T23%3A42%3A08IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010404&rft.volume=285&rft.issue=13&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1774&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft.eisbn=&rft_dat=<gale_ofa>72986125</gale_ofa>&rft_id=info:oai/>]]></sear:openurlfulltext>\n
+        \         <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A48IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A48IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A49IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A49IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A48IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010404&rft.volume=285&rft.issue=13&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1774&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>72986125</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A48IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010404&rft.volume=285&rft.issue=13&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1774&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>72986125</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A49IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010404&rft.volume=285&rft.issue=13&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1774&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>72986125</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A49IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010404&rft.volume=285&rft.issue=13&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1774&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>72986125</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
         \         </sear:LINKS>\n        </sear:DOC>\n        <sear:DOC LOCAL=\"false\"
         SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
-        NO=\"4\" RANK=\"1.0\" ID=\"139874944\">\n          <prim:PrimoNMBib xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
-        xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n
-        \           <prim:record>\n              <prim:control>\n                <prim:sourcerecordid>71325923</prim:sourcerecordid>\n
+        NO=\"5\" RANK=\"0.5732081\" ID=\"285229872\">\n          <prim:PrimoNMBib
+        xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
+        xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n            <prim:record>\n
+        \             <prim:control>\n                <prim:sourcerecordid>71325923</prim:sourcerecordid>\n
         \               <prim:sourceid>gale_ofa</prim:sourceid>\n                <prim:recordid>TN_gale_ofa71325923</prim:recordid>\n
         \               <prim:sourceformat>XML</prim:sourceformat>\n                <prim:sourcesystem>Other</prim:sourcesystem>\n
         \             </prim:control>\n              <prim:display>\n                <prim:type>article</prim:type>\n
@@ -400,10 +482,12 @@ http_interactions:
         &lt;/b>0098-7484</prim:identifier>\n                <prim:subject>&lt;span
         class=\"searchword\">Cancer&lt;/span> -- Bibliography</prim:subject>\n                <prim:source>Cengage
         Learning, Inc.</prim:source>\n                <prim:lds50>peer_reviewed</prim:lds50>\n
-        \               <prim:version>2</prim:version>\n                <prim:snippet/>\n
+        \               <prim:version>2</prim:version>\n                <prim:snippetfield>subject</prim:snippetfield>\n
+        \               <prim:snippet>&lt;span class=\"searchword\">Cancer&lt;/span>--Bibliography</prim:snippet>\n
         \             </prim:display>\n              <prim:links>\n                <prim:openurl>$$Topenurl_article</prim:openurl>\n
         \               <prim:openurlfulltext>$$Topenurlfull_article</prim:openurlfulltext>\n
-        \             </prim:links>\n              <prim:search>\n                <prim:title>&lt;span
+        \             </prim:links>\n              <prim:search>\n                <prim:scope>gale_onefileg</prim:scope>\n
+        \               <prim:scope>gale_onefilea</prim:scope>\n                <prim:title>&lt;span
         class=\"searchword\">Cancer&lt;/span>.</prim:title>\n                <prim:subject>Cancer--Bibliography</prim:subject>\n
         \               <prim:general>American Medical Association</prim:general>\n
         \               <prim:general>Cengage Learning, Inc.</prim:general>\n                <prim:sourceid>gale_ofa</prim:sourceid>\n
@@ -414,21 +498,21 @@ http_interactions:
         \               <prim:searchscope>OneFile</prim:searchscope>\n                <prim:scope>OneFile</prim:scope>\n
         \             </prim:search>\n              <prim:sort>\n                <prim:title>Cancer.</prim:title>\n
         \               <prim:creationdate>20010228</prim:creationdate>\n              </prim:sort>\n
-        \             <prim:facets>\n                <prim:creationdate>2001</prim:creationdate>\n
+        \             <prim:facets>\n                <prim:frbrgroupid>4097060424542046732</prim:frbrgroupid>\n
+        \               <prim:frbrtype>5</prim:frbrtype>\n                <prim:creationdate>2001</prim:creationdate>\n
         \               <prim:topic>Cancer–Bibliography</prim:topic>\n                <prim:collection>OneFile
         (GALE)</prim:collection>\n                <prim:prefilter>articles</prim:prefilter>\n
         \               <prim:rsrctype>articles</prim:rsrctype>\n                <prim:jtitle>JAMA,
         The Journal of the American Medical Association</prim:jtitle>\n                <prim:toplevel>peer_reviewed</prim:toplevel>\n
-        \               <prim:frbrgroupid>4097060424542046732</prim:frbrgroupid>\n
-        \               <prim:frbrtype>5</prim:frbrtype>\n              </prim:facets>\n
-        \             <prim:frbr>\n                <prim:t>2</prim:t>\n                <prim:k1>2001</prim:k1>\n
-        \               <prim:k2>00987484</prim:k2>\n                <prim:k4>285</prim:k4>\n
-        \               <prim:k5>8</prim:k5>\n                <prim:k6>1076</prim:k6>\n
-        \               <prim:k7>jama the journal of the american medical association</prim:k7>\n
-        \               <prim:k8>cancer</prim:k8>\n                <prim:k9>cancer</prim:k9>\n
-        \             </prim:frbr>\n              <prim:delivery>\n                <prim:delcategory>Remote
-        Search Resource</prim:delcategory>\n                <prim:fulltext>fulltext</prim:fulltext>\n
-        \             </prim:delivery>\n              <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
+        \             </prim:facets>\n              <prim:frbr>\n                <prim:t>2</prim:t>\n
+        \               <prim:k1>2001</prim:k1>\n                <prim:k2>00987484</prim:k2>\n
+        \               <prim:k4>285</prim:k4>\n                <prim:k5>8</prim:k5>\n
+        \               <prim:k6>1076</prim:k6>\n                <prim:k7>jama the
+        journal of the american medical association</prim:k7>\n                <prim:k8>cancer</prim:k8>\n
+        \               <prim:k9>cancer</prim:k9>\n              </prim:frbr>\n              <prim:delivery>\n
+        \               <prim:delcategory>Remote Search Resource</prim:delcategory>\n
+        \               <prim:fulltext>fulltext</prim:fulltext>\n              </prim:delivery>\n
+        \             <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
         \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>aggregator</prim:pcg_type>\n
         \             </prim:ranking>\n              <prim:addata>\n                <prim:atitle>Cancer.</prim:atitle>\n
         \               <prim:jtitle>JAMA, The Journal of the American Medical Association</prim:jtitle>\n
@@ -438,16 +522,21 @@ http_interactions:
         \               <prim:genre>article</prim:genre>\n                <prim:ristype>JOUR</prim:ristype>\n
         \               <prim:pub>American Medical Association</prim:pub>\n                <prim:lad01>gale_ofa</prim:lad01>\n
         \             </prim:addata>\n            </prim:record>\n          </prim:PrimoNMBib>\n
-        \         <sear:GETIT GetIt2=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-09-18T23%3A42%3A08IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=20010314&amp;rft.volume=285&amp;rft.issue=10&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=1363&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0098-7484&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.eisbn=&amp;rft_dat=&lt;gale_hrca>71838595&lt;/gale_hrca>&amp;rft_id=info:oai/>\"
-        GetIt1=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-09-18T23%3A42%3A08IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=20010314&amp;rft.volume=285&amp;rft.issue=10&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=1363&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0098-7484&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft.eisbn=&amp;rft_dat=&lt;gale_hrca>71838595&lt;/gale_hrca>&amp;rft_id=info:oai/>\"
-        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-09-18T23%3A42%3A08IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010228&rft.volume=285&rft.issue=8&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1076&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.eisbn=&rft_dat=<gale_ofa>71325923</gale_ofa>&rft_id=info:oai/>]]></sear:openurl>\n
-        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-09-18T23%3A42%3A08IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010228&rft.volume=285&rft.issue=8&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1076&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft.eisbn=&rft_dat=<gale_ofa>71325923</gale_ofa>&rft_id=info:oai/>]]></sear:openurlfulltext>\n
+        \         <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A48IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A48IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A49IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A49IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A48IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010228&rft.volume=285&rft.issue=8&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1076&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>71325923</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A48IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010228&rft.volume=285&rft.issue=8&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1076&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>71325923</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A49IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010228&rft.volume=285&rft.issue=8&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1076&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>71325923</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A49IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010228&rft.volume=285&rft.issue=8&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1076&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>71325923</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
         \         </sear:LINKS>\n        </sear:DOC>\n        <sear:DOC LOCAL=\"false\"
         SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
-        NO=\"5\" RANK=\"1.0\" ID=\"150796027\">\n          <prim:PrimoNMBib xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
-        xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n
-        \           <prim:record>\n              <prim:control>\n                <prim:sourcerecordid>71563136</prim:sourcerecordid>\n
-        \               <prim:sourceid>gale_hrca</prim:sourceid>\n                <prim:recordid>TN_gale_hrca71563136</prim:recordid>\n
+        NO=\"6\" RANK=\"0.5732081\" ID=\"293764719\">\n          <prim:PrimoNMBib
+        xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
+        xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n            <prim:record>\n
+        \             <prim:control>\n                <prim:sourcerecordid>71563136</prim:sourcerecordid>\n
+        \               <prim:sourceid>gale_ofa</prim:sourceid>\n                <prim:recordid>TN_gale_ofa71563136</prim:recordid>\n
         \               <prim:sourceformat>XML</prim:sourceformat>\n                <prim:sourcesystem>Other</prim:sourcesystem>\n
         \             </prim:control>\n              <prim:display>\n                <prim:type>article</prim:type>\n
         \               <prim:title>&lt;span class=\"searchword\">Cancer&lt;/span></prim:title>\n
@@ -456,35 +545,37 @@ http_interactions:
         &lt;/b>0098-7484</prim:identifier>\n                <prim:subject>&lt;span
         class=\"searchword\">Cancer&lt;/span> -- Bibliography</prim:subject>\n                <prim:source>Cengage
         Learning, Inc.</prim:source>\n                <prim:lds50>peer_reviewed</prim:lds50>\n
-        \               <prim:version>2</prim:version>\n                <prim:snippet/>\n
+        \               <prim:version>2</prim:version>\n                <prim:snippetfield>subject</prim:snippetfield>\n
+        \               <prim:snippet>&lt;span class=\"searchword\">Cancer&lt;/span>--Bibliography</prim:snippet>\n
         \             </prim:display>\n              <prim:links>\n                <prim:openurl>$$Topenurl_article</prim:openurl>\n
         \               <prim:openurlfulltext>$$Topenurlfull_article</prim:openurlfulltext>\n
-        \             </prim:links>\n              <prim:search>\n                <prim:title>&lt;span
+        \             </prim:links>\n              <prim:search>\n                <prim:scope>gale_onefileg</prim:scope>\n
+        \               <prim:scope>gale_onefilea</prim:scope>\n                <prim:title>&lt;span
         class=\"searchword\">Cancer&lt;/span>.</prim:title>\n                <prim:subject>Cancer--Bibliography</prim:subject>\n
         \               <prim:general>American Medical Association</prim:general>\n
-        \               <prim:general>Cengage Learning, Inc.</prim:general>\n                <prim:sourceid>gale_hrca</prim:sourceid>\n
-        \               <prim:recordid>gale_hrca71563136</prim:recordid>\n                <prim:issn>0098-7484</prim:issn>\n
+        \               <prim:general>Cengage Learning, Inc.</prim:general>\n                <prim:sourceid>gale_ofa</prim:sourceid>\n
+        \               <prim:recordid>gale_ofa71563136</prim:recordid>\n                <prim:issn>0098-7484</prim:issn>\n
         \               <prim:issn>00987484</prim:issn>\n                <prim:rsrctype>article</prim:rsrctype>\n
         \               <prim:creationdate>2001</prim:creationdate>\n                <prim:recordtype>article</prim:recordtype>\n
         \               <prim:addtitle>JAMA, The Journal of the American Medical Association</prim:addtitle>\n
-        \               <prim:searchscope>gale_hrca</prim:searchscope>\n                <prim:scope>gale_hrca</prim:scope>\n
+        \               <prim:searchscope>OneFile</prim:searchscope>\n                <prim:scope>OneFile</prim:scope>\n
         \             </prim:search>\n              <prim:sort>\n                <prim:title>Cancer.</prim:title>\n
         \               <prim:creationdate>20010307</prim:creationdate>\n              </prim:sort>\n
-        \             <prim:facets>\n                <prim:creationdate>2001</prim:creationdate>\n
-        \               <prim:topic>Cancer–Bibliography</prim:topic>\n                <prim:collection>Health
-        Reference Center Academic (Gale)</prim:collection>\n                <prim:prefilter>articles</prim:prefilter>\n
+        \             <prim:facets>\n                <prim:frbrgroupid>4097060424542046733</prim:frbrgroupid>\n
+        \               <prim:frbrtype>5</prim:frbrtype>\n                <prim:creationdate>2001</prim:creationdate>\n
+        \               <prim:topic>Cancer–Bibliography</prim:topic>\n                <prim:collection>OneFile
+        (GALE)</prim:collection>\n                <prim:prefilter>articles</prim:prefilter>\n
         \               <prim:rsrctype>articles</prim:rsrctype>\n                <prim:jtitle>JAMA,
         The Journal of the American Medical Association</prim:jtitle>\n                <prim:toplevel>peer_reviewed</prim:toplevel>\n
-        \               <prim:frbrgroupid>4097060424542046733</prim:frbrgroupid>\n
-        \               <prim:frbrtype>5</prim:frbrtype>\n              </prim:facets>\n
-        \             <prim:frbr>\n                <prim:t>2</prim:t>\n                <prim:k1>2001</prim:k1>\n
-        \               <prim:k2>00987484</prim:k2>\n                <prim:k4>285</prim:k4>\n
-        \               <prim:k5>9</prim:k5>\n                <prim:k6>1222</prim:k6>\n
-        \               <prim:k7>jama the journal of the american medical association</prim:k7>\n
-        \               <prim:k8>cancer</prim:k8>\n                <prim:k9>cancer</prim:k9>\n
-        \             </prim:frbr>\n              <prim:delivery>\n                <prim:delcategory>Remote
-        Search Resource</prim:delcategory>\n                <prim:fulltext>fulltext</prim:fulltext>\n
-        \             </prim:delivery>\n              <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
+        \             </prim:facets>\n              <prim:frbr>\n                <prim:t>2</prim:t>\n
+        \               <prim:k1>2001</prim:k1>\n                <prim:k2>00987484</prim:k2>\n
+        \               <prim:k4>285</prim:k4>\n                <prim:k5>9</prim:k5>\n
+        \               <prim:k6>1222</prim:k6>\n                <prim:k7>jama the
+        journal of the american medical association</prim:k7>\n                <prim:k8>cancer</prim:k8>\n
+        \               <prim:k9>cancer</prim:k9>\n              </prim:frbr>\n              <prim:delivery>\n
+        \               <prim:delcategory>Remote Search Resource</prim:delcategory>\n
+        \               <prim:fulltext>fulltext</prim:fulltext>\n              </prim:delivery>\n
+        \             <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
         \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>aggregator</prim:pcg_type>\n
         \             </prim:ranking>\n              <prim:addata>\n                <prim:atitle>Cancer.</prim:atitle>\n
         \               <prim:jtitle>JAMA, The Journal of the American Medical Association</prim:jtitle>\n
@@ -492,15 +583,19 @@ http_interactions:
         \               <prim:volume>285</prim:volume>\n                <prim:issue>9</prim:issue>\n
         \               <prim:spage>1222</prim:spage>\n                <prim:issn>0098-7484</prim:issn>\n
         \               <prim:genre>article</prim:genre>\n                <prim:ristype>JOUR</prim:ristype>\n
-        \               <prim:pub>American Medical Association</prim:pub>\n                <prim:lad01>gale_hrca</prim:lad01>\n
+        \               <prim:pub>American Medical Association</prim:pub>\n                <prim:lad01>gale_ofa</prim:lad01>\n
         \             </prim:addata>\n            </prim:record>\n          </prim:PrimoNMBib>\n
-        \         <sear:GETIT GetIt2=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-09-18T23%3A42%3A08IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=20010314&amp;rft.volume=285&amp;rft.issue=10&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=1363&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0098-7484&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.eisbn=&amp;rft_dat=&lt;gale_hrca>71838595&lt;/gale_hrca>&amp;rft_id=info:oai/>\"
-        GetIt1=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-09-18T23%3A42%3A08IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=20010314&amp;rft.volume=285&amp;rft.issue=10&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=1363&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0098-7484&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft.eisbn=&amp;rft_dat=&lt;gale_hrca>71838595&lt;/gale_hrca>&amp;rft_id=info:oai/>\"
-        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-09-18T23%3A42%3A08IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010307&rft.volume=285&rft.issue=9&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1222&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.eisbn=&rft_dat=<gale_hrca>71563136</gale_hrca>&rft_id=info:oai/>]]></sear:openurl>\n
-        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-09-18T23%3A42%3A08IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010307&rft.volume=285&rft.issue=9&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1222&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft.eisbn=&rft_dat=<gale_hrca>71563136</gale_hrca>&rft_id=info:oai/>]]></sear:openurlfulltext>\n
+        \         <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A48IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A48IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A49IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A49IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A48IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010307&rft.volume=285&rft.issue=9&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1222&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>71563136</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A48IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010307&rft.volume=285&rft.issue=9&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1222&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>71563136</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A49IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010307&rft.volume=285&rft.issue=9&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1222&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>71563136</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A49IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010307&rft.volume=285&rft.issue=9&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1222&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>71563136</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
         \         </sear:LINKS>\n        </sear:DOC>\n        <sear:DOC LOCAL=\"false\"
         SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
-        NO=\"6\" RANK=\"0.99952966\" ID=\"96171503\">\n          <prim:PrimoNMBib
+        NO=\"7\" RANK=\"0.5729385\" ID=\"238340115\">\n          <prim:PrimoNMBib
         xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
         xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n            <prim:record>\n
         \             <prim:control>\n                <prim:sourcerecordid>69495054</prim:sourcerecordid>\n
@@ -514,10 +609,14 @@ http_interactions:
         class=\"searchword\">Cancer&lt;/span> -- Bibliography ; &lt;span class=\"searchword\">Cancer&lt;/span>
         Vaccines -- Bibliography</prim:subject>\n                <prim:source>Cengage
         Learning, Inc.</prim:source>\n                <prim:lds50>peer_reviewed</prim:lds50>\n
-        \               <prim:version>2</prim:version>\n                <prim:snippet/>\n
-        \             </prim:display>\n              <prim:links>\n                <prim:openurl>$$Topenurl_article</prim:openurl>\n
+        \               <prim:version>2</prim:version>\n                <prim:snippetfield>subject</prim:snippetfield>\n
+        \               <prim:snippetfield>subject</prim:snippetfield>\n                <prim:snippet>&lt;span
+        class=\"searchword\">Cancer&lt;/span> vaccines--Bibliography... Breast &lt;span
+        class=\"searchword\">cancer&lt;/span>--Bibliography</prim:snippet>\n              </prim:display>\n
+        \             <prim:links>\n                <prim:openurl>$$Topenurl_article</prim:openurl>\n
         \               <prim:openurlfulltext>$$Topenurlfull_article</prim:openurlfulltext>\n
-        \             </prim:links>\n              <prim:search>\n                <prim:title>&lt;span
+        \             </prim:links>\n              <prim:search>\n                <prim:scope>gale_onefileg</prim:scope>\n
+        \               <prim:scope>gale_onefilea</prim:scope>\n                <prim:title>&lt;span
         class=\"searchword\">Cancer&lt;/span>.</prim:title>\n                <prim:subject>Breast
         cancer--Bibliography</prim:subject>\n                <prim:subject>Cancer
         vaccines--Bibliography</prim:subject>\n                <prim:general>American
@@ -530,22 +629,22 @@ http_interactions:
         \               <prim:searchscope>OneFile</prim:searchscope>\n                <prim:scope>OneFile</prim:scope>\n
         \             </prim:search>\n              <prim:sort>\n                <prim:title>Cancer.</prim:title>\n
         \               <prim:creationdate>20010124</prim:creationdate>\n              </prim:sort>\n
-        \             <prim:facets>\n                <prim:creationdate>2001</prim:creationdate>\n
+        \             <prim:facets>\n                <prim:frbrgroupid>4097060424542046728</prim:frbrgroupid>\n
+        \               <prim:frbrtype>5</prim:frbrtype>\n                <prim:creationdate>2001</prim:creationdate>\n
         \               <prim:topic>Breast Cancer–Bibliography</prim:topic>\n                <prim:topic>Cancer
         Vaccines–Bibliography</prim:topic>\n                <prim:collection>OneFile
         (GALE)</prim:collection>\n                <prim:prefilter>articles</prim:prefilter>\n
         \               <prim:rsrctype>articles</prim:rsrctype>\n                <prim:jtitle>JAMA,
         The Journal of the American Medical Association</prim:jtitle>\n                <prim:toplevel>peer_reviewed</prim:toplevel>\n
-        \               <prim:frbrgroupid>4097060424542046728</prim:frbrgroupid>\n
-        \               <prim:frbrtype>5</prim:frbrtype>\n              </prim:facets>\n
-        \             <prim:frbr>\n                <prim:t>2</prim:t>\n                <prim:k1>2001</prim:k1>\n
-        \               <prim:k2>00987484</prim:k2>\n                <prim:k4>285</prim:k4>\n
-        \               <prim:k5>4</prim:k5>\n                <prim:k6>470</prim:k6>\n
-        \               <prim:k7>jama the journal of the american medical association</prim:k7>\n
-        \               <prim:k8>cancer</prim:k8>\n                <prim:k9>cancer</prim:k9>\n
-        \             </prim:frbr>\n              <prim:delivery>\n                <prim:delcategory>Remote
-        Search Resource</prim:delcategory>\n                <prim:fulltext>fulltext</prim:fulltext>\n
-        \             </prim:delivery>\n              <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
+        \             </prim:facets>\n              <prim:frbr>\n                <prim:t>2</prim:t>\n
+        \               <prim:k1>2001</prim:k1>\n                <prim:k2>00987484</prim:k2>\n
+        \               <prim:k4>285</prim:k4>\n                <prim:k5>4</prim:k5>\n
+        \               <prim:k6>470</prim:k6>\n                <prim:k7>jama the
+        journal of the american medical association</prim:k7>\n                <prim:k8>cancer</prim:k8>\n
+        \               <prim:k9>cancer</prim:k9>\n              </prim:frbr>\n              <prim:delivery>\n
+        \               <prim:delcategory>Remote Search Resource</prim:delcategory>\n
+        \               <prim:fulltext>fulltext</prim:fulltext>\n              </prim:delivery>\n
+        \             <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
         \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>aggregator</prim:pcg_type>\n
         \             </prim:ranking>\n              <prim:addata>\n                <prim:atitle>Cancer.</prim:atitle>\n
         \               <prim:jtitle>JAMA, The Journal of the American Medical Association</prim:jtitle>\n
@@ -555,15 +654,20 @@ http_interactions:
         \               <prim:genre>article</prim:genre>\n                <prim:ristype>JOUR</prim:ristype>\n
         \               <prim:pub>American Medical Association</prim:pub>\n                <prim:lad01>gale_ofa</prim:lad01>\n
         \             </prim:addata>\n            </prim:record>\n          </prim:PrimoNMBib>\n
-        \         <sear:GETIT GetIt2=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-09-18T23%3A42%3A08IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=20010314&amp;rft.volume=285&amp;rft.issue=10&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=1363&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0098-7484&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.eisbn=&amp;rft_dat=&lt;gale_hrca>71838595&lt;/gale_hrca>&amp;rft_id=info:oai/>\"
-        GetIt1=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-09-18T23%3A42%3A08IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=20010314&amp;rft.volume=285&amp;rft.issue=10&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=1363&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0098-7484&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft.eisbn=&amp;rft_dat=&lt;gale_hrca>71838595&lt;/gale_hrca>&amp;rft_id=info:oai/>\"
-        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-09-18T23%3A42%3A08IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010124&rft.volume=285&rft.issue=4&rft.part=&rft.quarter=&rft.ssn=&rft.spage=470&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.eisbn=&rft_dat=<gale_ofa>69495054</gale_ofa>&rft_id=info:oai/>]]></sear:openurl>\n
-        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-09-18T23%3A42%3A08IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010124&rft.volume=285&rft.issue=4&rft.part=&rft.quarter=&rft.ssn=&rft.spage=470&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft.eisbn=&rft_dat=<gale_ofa>69495054</gale_ofa>&rft_id=info:oai/>]]></sear:openurlfulltext>\n
+        \         <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A48IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A48IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A49IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A49IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A48IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010124&rft.volume=285&rft.issue=4&rft.part=&rft.quarter=&rft.ssn=&rft.spage=470&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>69495054</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A48IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010124&rft.volume=285&rft.issue=4&rft.part=&rft.quarter=&rft.ssn=&rft.spage=470&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>69495054</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A49IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010124&rft.volume=285&rft.issue=4&rft.part=&rft.quarter=&rft.ssn=&rft.spage=470&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>69495054</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A49IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010124&rft.volume=285&rft.issue=4&rft.part=&rft.quarter=&rft.ssn=&rft.spage=470&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>69495054</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
         \         </sear:LINKS>\n        </sear:DOC>\n        <sear:DOC LOCAL=\"false\"
         SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
-        NO=\"7\" RANK=\"0.999379\" ID=\"63900971\">\n          <prim:PrimoNMBib xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
-        xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n
-        \           <prim:record>\n              <prim:control>\n                <prim:sourcerecordid>75029820</prim:sourcerecordid>\n
+        NO=\"8\" RANK=\"0.57285213\" ID=\"344059317\">\n          <prim:PrimoNMBib
+        xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
+        xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n            <prim:record>\n
+        \             <prim:control>\n                <prim:sourcerecordid>75029820</prim:sourcerecordid>\n
         \               <prim:sourceid>gale_ofa</prim:sourceid>\n                <prim:recordid>TN_gale_ofa75029820</prim:recordid>\n
         \               <prim:sourceformat>XML</prim:sourceformat>\n                <prim:sourcesystem>Other</prim:sourcesystem>\n
         \             </prim:control>\n              <prim:display>\n                <prim:type>article</prim:type>\n
@@ -573,10 +677,12 @@ http_interactions:
         &lt;/b>0098-7484</prim:identifier>\n                <prim:subject>Prostate
         &lt;span class=\"searchword\">Cancer&lt;/span> -- Bibliography</prim:subject>\n
         \               <prim:source>Cengage Learning, Inc.</prim:source>\n                <prim:lds50>peer_reviewed</prim:lds50>\n
-        \               <prim:version>2</prim:version>\n                <prim:snippet/>\n
+        \               <prim:version>2</prim:version>\n                <prim:snippetfield>subject</prim:snippetfield>\n
+        \               <prim:snippet>Prostate &lt;span class=\"searchword\">cancer&lt;/span>--Bibliography</prim:snippet>\n
         \             </prim:display>\n              <prim:links>\n                <prim:openurl>$$Topenurl_article</prim:openurl>\n
         \               <prim:openurlfulltext>$$Topenurlfull_article</prim:openurlfulltext>\n
-        \             </prim:links>\n              <prim:search>\n                <prim:title>&lt;span
+        \             </prim:links>\n              <prim:search>\n                <prim:scope>gale_onefilea</prim:scope>\n
+        \               <prim:scope>gale_onefileg</prim:scope>\n                <prim:title>&lt;span
         class=\"searchword\">Cancer&lt;/span>.</prim:title>\n                <prim:subject>Prostate
         cancer--Bibliography</prim:subject>\n                <prim:general>American
         Medical Association</prim:general>\n                <prim:general>Cengage
@@ -588,21 +694,21 @@ http_interactions:
         \               <prim:searchscope>OneFile</prim:searchscope>\n                <prim:scope>OneFile</prim:scope>\n
         \             </prim:search>\n              <prim:sort>\n                <prim:title>Cancer.</prim:title>\n
         \               <prim:creationdate>20010523</prim:creationdate>\n              </prim:sort>\n
-        \             <prim:facets>\n                <prim:creationdate>2001</prim:creationdate>\n
+        \             <prim:facets>\n                <prim:frbrgroupid>6042759724874213381</prim:frbrgroupid>\n
+        \               <prim:frbrtype>5</prim:frbrtype>\n                <prim:creationdate>2001</prim:creationdate>\n
         \               <prim:topic>Prostate Cancer–Bibliography</prim:topic>\n                <prim:collection>OneFile
         (GALE)</prim:collection>\n                <prim:prefilter>articles</prim:prefilter>\n
         \               <prim:rsrctype>articles</prim:rsrctype>\n                <prim:jtitle>JAMA,
         The Journal of the American Medical Association</prim:jtitle>\n                <prim:toplevel>peer_reviewed</prim:toplevel>\n
-        \               <prim:frbrgroupid>6042759724874213381</prim:frbrgroupid>\n
-        \               <prim:frbrtype>5</prim:frbrtype>\n              </prim:facets>\n
-        \             <prim:frbr>\n                <prim:t>2</prim:t>\n                <prim:k1>2001</prim:k1>\n
-        \               <prim:k2>00987484</prim:k2>\n                <prim:k4>285</prim:k4>\n
-        \               <prim:k5>20</prim:k5>\n                <prim:k6>2653</prim:k6>\n
-        \               <prim:k7>jama the journal of the american medical association</prim:k7>\n
-        \               <prim:k8>cancer</prim:k8>\n                <prim:k9>cancer</prim:k9>\n
-        \             </prim:frbr>\n              <prim:delivery>\n                <prim:delcategory>Remote
-        Search Resource</prim:delcategory>\n                <prim:fulltext>fulltext</prim:fulltext>\n
-        \             </prim:delivery>\n              <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
+        \             </prim:facets>\n              <prim:frbr>\n                <prim:t>2</prim:t>\n
+        \               <prim:k1>2001</prim:k1>\n                <prim:k2>00987484</prim:k2>\n
+        \               <prim:k4>285</prim:k4>\n                <prim:k5>20</prim:k5>\n
+        \               <prim:k6>2653</prim:k6>\n                <prim:k7>jama the
+        journal of the american medical association</prim:k7>\n                <prim:k8>cancer</prim:k8>\n
+        \               <prim:k9>cancer</prim:k9>\n              </prim:frbr>\n              <prim:delivery>\n
+        \               <prim:delcategory>Remote Search Resource</prim:delcategory>\n
+        \               <prim:fulltext>fulltext</prim:fulltext>\n              </prim:delivery>\n
+        \             <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
         \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>aggregator</prim:pcg_type>\n
         \             </prim:ranking>\n              <prim:addata>\n                <prim:atitle>Cancer.</prim:atitle>\n
         \               <prim:jtitle>JAMA, The Journal of the American Medical Association</prim:jtitle>\n
@@ -612,16 +718,21 @@ http_interactions:
         \               <prim:genre>article</prim:genre>\n                <prim:ristype>JOUR</prim:ristype>\n
         \               <prim:pub>American Medical Association</prim:pub>\n                <prim:lad01>gale_ofa</prim:lad01>\n
         \             </prim:addata>\n            </prim:record>\n          </prim:PrimoNMBib>\n
-        \         <sear:GETIT GetIt2=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-09-18T23%3A42%3A08IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=20010314&amp;rft.volume=285&amp;rft.issue=10&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=1363&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0098-7484&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.eisbn=&amp;rft_dat=&lt;gale_hrca>71838595&lt;/gale_hrca>&amp;rft_id=info:oai/>\"
-        GetIt1=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-09-18T23%3A42%3A08IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=20010314&amp;rft.volume=285&amp;rft.issue=10&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=1363&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0098-7484&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft.eisbn=&amp;rft_dat=&lt;gale_hrca>71838595&lt;/gale_hrca>&amp;rft_id=info:oai/>\"
-        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-09-18T23%3A42%3A08IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010523&rft.volume=285&rft.issue=20&rft.part=&rft.quarter=&rft.ssn=&rft.spage=2653&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.eisbn=&rft_dat=<gale_ofa>75029820</gale_ofa>&rft_id=info:oai/>]]></sear:openurl>\n
-        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-09-18T23%3A42%3A08IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010523&rft.volume=285&rft.issue=20&rft.part=&rft.quarter=&rft.ssn=&rft.spage=2653&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft.eisbn=&rft_dat=<gale_ofa>75029820</gale_ofa>&rft_id=info:oai/>]]></sear:openurlfulltext>\n
+        \         <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A48IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A48IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A49IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A49IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A48IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010523&rft.volume=285&rft.issue=20&rft.part=&rft.quarter=&rft.ssn=&rft.spage=2653&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>75029820</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A48IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010523&rft.volume=285&rft.issue=20&rft.part=&rft.quarter=&rft.ssn=&rft.spage=2653&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>75029820</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A49IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010523&rft.volume=285&rft.issue=20&rft.part=&rft.quarter=&rft.ssn=&rft.spage=2653&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>75029820</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A49IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010523&rft.volume=285&rft.issue=20&rft.part=&rft.quarter=&rft.ssn=&rft.spage=2653&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>75029820</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
         \         </sear:LINKS>\n        </sear:DOC>\n        <sear:DOC LOCAL=\"false\"
         SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
-        NO=\"8\" RANK=\"0.9990686\" ID=\"63382477\">\n          <prim:PrimoNMBib xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
-        xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n
-        \           <prim:record>\n              <prim:control>\n                <prim:sourcerecordid>68874569</prim:sourcerecordid>\n
-        \               <prim:sourceid>gale_hrca</prim:sourceid>\n                <prim:recordid>TN_gale_hrca68874569</prim:recordid>\n
+        NO=\"9\" RANK=\"0.5726742\" ID=\"206284933\">\n          <prim:PrimoNMBib
+        xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
+        xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n            <prim:record>\n
+        \             <prim:control>\n                <prim:sourcerecordid>68874569</prim:sourcerecordid>\n
+        \               <prim:sourceid>gale_ofa</prim:sourceid>\n                <prim:recordid>TN_gale_ofa68874569</prim:recordid>\n
         \               <prim:sourceformat>XML</prim:sourceformat>\n                <prim:sourcesystem>Other</prim:sourcesystem>\n
         \             </prim:control>\n              <prim:display>\n                <prim:type>article</prim:type>\n
         \               <prim:title>&lt;span class=\"searchword\">Cancer&lt;/span></prim:title>\n
@@ -630,36 +741,38 @@ http_interactions:
         &lt;/b>0098-7484</prim:identifier>\n                <prim:subject>Oncology
         -- Bibliography ; &lt;span class=\"searchword\">Cancer&lt;/span> -- Bibliography</prim:subject>\n
         \               <prim:source>Cengage Learning, Inc.</prim:source>\n                <prim:lds50>peer_reviewed</prim:lds50>\n
-        \               <prim:version>2</prim:version>\n                <prim:snippet/>\n
+        \               <prim:version>2</prim:version>\n                <prim:snippetfield>subject</prim:snippetfield>\n
+        \               <prim:snippet>&lt;span class=\"searchword\">Cancer&lt;/span>--Bibliography</prim:snippet>\n
         \             </prim:display>\n              <prim:links>\n                <prim:openurl>$$Topenurl_article</prim:openurl>\n
         \               <prim:openurlfulltext>$$Topenurlfull_article</prim:openurlfulltext>\n
-        \             </prim:links>\n              <prim:search>\n                <prim:title>&lt;span
+        \             </prim:links>\n              <prim:search>\n                <prim:scope>gale_onefileg</prim:scope>\n
+        \               <prim:scope>gale_onefilea</prim:scope>\n                <prim:title>&lt;span
         class=\"searchword\">Cancer&lt;/span>.</prim:title>\n                <prim:subject>Oncology--Bibliography</prim:subject>\n
         \               <prim:subject>Cancer--Bibliography</prim:subject>\n                <prim:general>American
         Medical Association</prim:general>\n                <prim:general>Cengage
-        Learning, Inc.</prim:general>\n                <prim:sourceid>gale_hrca</prim:sourceid>\n
-        \               <prim:recordid>gale_hrca68874569</prim:recordid>\n                <prim:issn>0098-7484</prim:issn>\n
+        Learning, Inc.</prim:general>\n                <prim:sourceid>gale_ofa</prim:sourceid>\n
+        \               <prim:recordid>gale_ofa68874569</prim:recordid>\n                <prim:issn>0098-7484</prim:issn>\n
         \               <prim:issn>00987484</prim:issn>\n                <prim:rsrctype>article</prim:rsrctype>\n
         \               <prim:creationdate>2001</prim:creationdate>\n                <prim:recordtype>article</prim:recordtype>\n
         \               <prim:addtitle>JAMA, The Journal of the American Medical Association</prim:addtitle>\n
-        \               <prim:searchscope>gale_hrca</prim:searchscope>\n                <prim:scope>gale_hrca</prim:scope>\n
+        \               <prim:searchscope>OneFile</prim:searchscope>\n                <prim:scope>OneFile</prim:scope>\n
         \             </prim:search>\n              <prim:sort>\n                <prim:title>Cancer.</prim:title>\n
         \               <prim:creationdate>20010103</prim:creationdate>\n              </prim:sort>\n
-        \             <prim:facets>\n                <prim:creationdate>2001</prim:creationdate>\n
+        \             <prim:facets>\n                <prim:frbrgroupid>4097060424542046725</prim:frbrgroupid>\n
+        \               <prim:frbrtype>5</prim:frbrtype>\n                <prim:creationdate>2001</prim:creationdate>\n
         \               <prim:topic>Oncology–Bibliography</prim:topic>\n                <prim:topic>Cancer–Bibliography</prim:topic>\n
-        \               <prim:collection>Health Reference Center Academic (Gale)</prim:collection>\n
-        \               <prim:prefilter>articles</prim:prefilter>\n                <prim:rsrctype>articles</prim:rsrctype>\n
-        \               <prim:jtitle>JAMA, The Journal of the American Medical Association</prim:jtitle>\n
-        \               <prim:toplevel>peer_reviewed</prim:toplevel>\n                <prim:frbrgroupid>4097060424542046725</prim:frbrgroupid>\n
-        \               <prim:frbrtype>5</prim:frbrtype>\n              </prim:facets>\n
-        \             <prim:frbr>\n                <prim:t>2</prim:t>\n                <prim:k1>2001</prim:k1>\n
-        \               <prim:k2>00987484</prim:k2>\n                <prim:k4>285</prim:k4>\n
-        \               <prim:k5>1</prim:k5>\n                <prim:k6>97</prim:k6>\n
-        \               <prim:k7>jama the journal of the american medical association</prim:k7>\n
-        \               <prim:k8>cancer</prim:k8>\n                <prim:k9>cancer</prim:k9>\n
-        \             </prim:frbr>\n              <prim:delivery>\n                <prim:delcategory>Remote
-        Search Resource</prim:delcategory>\n                <prim:fulltext>fulltext</prim:fulltext>\n
-        \             </prim:delivery>\n              <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
+        \               <prim:collection>OneFile (GALE)</prim:collection>\n                <prim:prefilter>articles</prim:prefilter>\n
+        \               <prim:rsrctype>articles</prim:rsrctype>\n                <prim:jtitle>JAMA,
+        The Journal of the American Medical Association</prim:jtitle>\n                <prim:toplevel>peer_reviewed</prim:toplevel>\n
+        \             </prim:facets>\n              <prim:frbr>\n                <prim:t>2</prim:t>\n
+        \               <prim:k1>2001</prim:k1>\n                <prim:k2>00987484</prim:k2>\n
+        \               <prim:k4>285</prim:k4>\n                <prim:k5>1</prim:k5>\n
+        \               <prim:k6>97</prim:k6>\n                <prim:k7>jama the journal
+        of the american medical association</prim:k7>\n                <prim:k8>cancer</prim:k8>\n
+        \               <prim:k9>cancer</prim:k9>\n              </prim:frbr>\n              <prim:delivery>\n
+        \               <prim:delcategory>Remote Search Resource</prim:delcategory>\n
+        \               <prim:fulltext>fulltext</prim:fulltext>\n              </prim:delivery>\n
+        \             <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
         \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>aggregator</prim:pcg_type>\n
         \             </prim:ranking>\n              <prim:addata>\n                <prim:atitle>Cancer.</prim:atitle>\n
         \               <prim:jtitle>JAMA, The Journal of the American Medical Association</prim:jtitle>\n
@@ -667,15 +780,19 @@ http_interactions:
         \               <prim:volume>285</prim:volume>\n                <prim:issue>1</prim:issue>\n
         \               <prim:spage>97</prim:spage>\n                <prim:issn>0098-7484</prim:issn>\n
         \               <prim:genre>article</prim:genre>\n                <prim:ristype>JOUR</prim:ristype>\n
-        \               <prim:pub>American Medical Association</prim:pub>\n                <prim:lad01>gale_hrca</prim:lad01>\n
+        \               <prim:pub>American Medical Association</prim:pub>\n                <prim:lad01>gale_ofa</prim:lad01>\n
         \             </prim:addata>\n            </prim:record>\n          </prim:PrimoNMBib>\n
-        \         <sear:GETIT GetIt2=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-09-18T23%3A42%3A08IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=20010314&amp;rft.volume=285&amp;rft.issue=10&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=1363&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0098-7484&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.eisbn=&amp;rft_dat=&lt;gale_hrca>71838595&lt;/gale_hrca>&amp;rft_id=info:oai/>\"
-        GetIt1=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-09-18T23%3A42%3A08IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=20010314&amp;rft.volume=285&amp;rft.issue=10&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=1363&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0098-7484&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft.eisbn=&amp;rft_dat=&lt;gale_hrca>71838595&lt;/gale_hrca>&amp;rft_id=info:oai/>\"
-        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-09-18T23%3A42%3A08IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010103&rft.volume=285&rft.issue=1&rft.part=&rft.quarter=&rft.ssn=&rft.spage=97&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.eisbn=&rft_dat=<gale_hrca>68874569</gale_hrca>&rft_id=info:oai/>]]></sear:openurl>\n
-        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-09-18T23%3A42%3A08IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010103&rft.volume=285&rft.issue=1&rft.part=&rft.quarter=&rft.ssn=&rft.spage=97&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft.eisbn=&rft_dat=<gale_hrca>68874569</gale_hrca>&rft_id=info:oai/>]]></sear:openurlfulltext>\n
+        \         <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A48IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A48IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A49IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A49IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A48IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010103&rft.volume=285&rft.issue=1&rft.part=&rft.quarter=&rft.ssn=&rft.spage=97&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>68874569</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A48IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010103&rft.volume=285&rft.issue=1&rft.part=&rft.quarter=&rft.ssn=&rft.spage=97&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>68874569</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A49IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010103&rft.volume=285&rft.issue=1&rft.part=&rft.quarter=&rft.ssn=&rft.spage=97&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>68874569</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A49IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer.&rft.jtitle=JAMA,%20The%20Journal%20of%20the%20American%20Medical%20Association&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=&rft.aucorp=&rft.date=20010103&rft.volume=285&rft.issue=1&rft.part=&rft.quarter=&rft.ssn=&rft.spage=97&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0098-7484&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>68874569</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
         \         </sear:LINKS>\n        </sear:DOC>\n        <sear:DOC LOCAL=\"false\"
         SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
-        NO=\"9\" RANK=\"0.9985607\" ID=\"109505185\">\n          <prim:PrimoNMBib
+        NO=\"10\" RANK=\"0.57238305\" ID=\"174316178\">\n          <prim:PrimoNMBib
         xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
         xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n            <prim:record>\n
         \             <prim:control>\n                <prim:sourcerecordid>AID-CNCR21>3.0.CO;2-Q</prim:sourcerecordid>\n
@@ -710,20 +827,22 @@ http_interactions:
         only practical strategy for achieving risk reduction among minority groups.
         1998;83:1775‐1783. ©</prim:description>\n                <prim:language>eng</prim:language>\n
         \               <prim:source>John Wiley &amp; Sons, Inc.</prim:source>\n                <prim:lds50>peer_reviewed</prim:lds50>\n
-        \               <prim:version>1</prim:version>\n                <prim:snippetfield>description</prim:snippetfield>\n
-        \               <prim:snippetfield>description</prim:snippetfield>\n                <prim:snippetfield>description</prim:snippetfield>\n
-        \               <prim:snippet>, and fitness in &lt;span class=\"searchword\">cancer&lt;/span>.
-        Culture and socioeconomic status strongly influence both individual and societal
-        attitudes and behaviors regarding food, fitness, and weight status. These
-        factors...  are significant not only as they relate to &lt;span class=\"searchword\">cancer&lt;/span>
+        \               <prim:snippetfield>description</prim:snippetfield>\n                <prim:snippetfield>addtitle</prim:snippetfield>\n
+        \               <prim:snippetfield>description</prim:snippetfield>\n                <prim:snippetfield>subject</prim:snippetfield>\n
+        \               <prim:snippetfield>description</prim:snippetfield>\n                <prim:snippet>,
+        and fitness in &lt;span class=\"searchword\">cancer&lt;/span>. Culture and
+        socioeconomic status strongly influence both individual and societal attitudes
+        and behaviors regarding food, fitness, and weight status. These factors...
+        Interdisciplinary International Journal of the American &lt;span class=\"searchword\">Cancer&lt;/span>
+        Society...  are significant not only as they relate to &lt;span class=\"searchword\">cancer&lt;/span>
         development but as considerations in developing programs to modify risk behaviors.
         There is a substantial need for more &lt;span class=\"searchword\">cancer&lt;/span>
-        research focusing on both... Among minorities and the medically underserved,
-        the relationship between life style factors involving diet, nutrition, and
-        fitness and the risks for &lt;span class=\"searchword\">cancer&lt;/span> is
-        complex, significant, and controversial</prim:snippet>\n              </prim:display>\n
-        \             <prim:links>\n                <prim:openurl>$$Topenurl_article</prim:openurl>\n
-        \               <prim:openurlfulltext>$$Topenurlfull_article</prim:openurlfulltext>\n
+        research focusing on both... &lt;span class=\"searchword\">Cancer&lt;/span>
+        Prevention... Among minorities and the medically underserved, the relationship
+        between life style factors involving diet, nutrition, and fitness and the
+        risks for &lt;span class=\"searchword\">cancer&lt;/span> is complex, significant,
+        and controversial</prim:snippet>\n              </prim:display>\n              <prim:links>\n
+        \               <prim:openurl>$$Topenurl_article</prim:openurl>\n                <prim:openurlfulltext>$$Topenurlfull_article</prim:openurlfulltext>\n
         \             </prim:links>\n              <prim:search>\n                <prim:creatorcontrib>Fulgoni,
         Victor L.</prim:creatorcontrib>\n                <prim:creatorcontrib>Amelie
         G., Victor L.</prim:creatorcontrib>\n                <prim:title>&lt;span
@@ -763,7 +882,8 @@ http_interactions:
         \             <prim:sort>\n                <prim:title>Cancer</prim:title>\n
         \               <prim:author>Fulgoni, Victor L. ; Amelie G., Victor L.</prim:author>\n
         \               <prim:creationdate>19981015</prim:creationdate>\n              </prim:sort>\n
-        \             <prim:facets>\n                <prim:language>eng</prim:language>\n
+        \             <prim:facets>\n                <prim:frbrgroupid>905256086522418266</prim:frbrgroupid>\n
+        \               <prim:frbrtype>6</prim:frbrtype>\n                <prim:language>eng</prim:language>\n
         \               <prim:creationdate>1998</prim:creationdate>\n                <prim:topic>Minorities</prim:topic>\n
         \               <prim:topic>Diet</prim:topic>\n                <prim:topic>Nutrition</prim:topic>\n
         \               <prim:topic>Fitness</prim:topic>\n                <prim:topic>Behavior
@@ -773,17 +893,15 @@ http_interactions:
         \               <prim:creatorcontrib>Fulgoni, Victor L.</prim:creatorcontrib>\n
         \               <prim:creatorcontrib>Amelie G., Victor L.</prim:creatorcontrib>\n
         \               <prim:jtitle>Cancer</prim:jtitle>\n                <prim:toplevel>peer_reviewed</prim:toplevel>\n
-        \               <prim:frbrgroupid>-4153887031873808170</prim:frbrgroupid>\n
-        \               <prim:frbrtype>5</prim:frbrtype>\n              </prim:facets>\n
-        \             <prim:frbr>\n                <prim:t>2</prim:t>\n                <prim:k1>1998</prim:k1>\n
-        \               <prim:k2>0008543X</prim:k2>\n                <prim:k2>10970142</prim:k2>\n
-        \               <prim:k3>10.1002/(SICI)1097-0142(19981015)83:8+&lt;1775::AID-CNCR21>3.0.CO;2-Q</prim:k3>\n
+        \             </prim:facets>\n              <prim:frbr>\n                <prim:t>2</prim:t>\n
+        \               <prim:k1>1998</prim:k1>\n                <prim:k2>0008543X</prim:k2>\n
+        \               <prim:k2>10970142</prim:k2>\n                <prim:k3>10.1002/(SICI)1097-0142(19981015)83:8+&lt;1775::AID-CNCR21>3.0.CO;2-Q</prim:k3>\n
         \               <prim:k4>83</prim:k4>\n                <prim:k6>1775</prim:k6>\n
         \               <prim:k7>cancer</prim:k7>\n                <prim:k8>cancer</prim:k8>\n
         \               <prim:k9>cancer</prim:k9>\n                <prim:k15>victorlfulgoni</prim:k15>\n
         \               <prim:k16>fulgonivictorl</prim:k16>\n              </prim:frbr>\n
         \             <prim:delivery>\n                <prim:delcategory>Remote Search
-        Resource</prim:delcategory>\n                <prim:fulltext>no_fulltext</prim:fulltext>\n
+        Resource</prim:delcategory>\n                <prim:fulltext>fulltext</prim:fulltext>\n
         \             </prim:delivery>\n              <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
         \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>publisher</prim:pcg_type>\n
         \             </prim:ranking>\n              <prim:addata>\n                <prim:aulast>Fulgoni</prim:aulast>\n
@@ -816,12 +934,16 @@ http_interactions:
         \               <prim:cop>New York</prim:cop>\n                <prim:pub>John
         Wiley &amp; Sons, Inc.</prim:pub>\n                <prim:doi>10.1002/(SICI)1097-0142(19981015)83:8+&lt;1775::AID-CNCR21>3.0.CO;2-Q</prim:doi>\n
         \             </prim:addata>\n            </prim:record>\n          </prim:PrimoNMBib>\n
-        \         <sear:GETIT GetIt2=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-09-18T23%3A42%3A08IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=20010314&amp;rft.volume=285&amp;rft.issue=10&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=1363&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0098-7484&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.eisbn=&amp;rft_dat=&lt;gale_hrca>71838595&lt;/gale_hrca>&amp;rft_id=info:oai/>\"
-        GetIt1=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-09-18T23%3A42%3A08IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_hrca&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=JAMA%2C%20The%20Journal%20of%20the%20American%20Medical%20Association&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=&amp;rft.aucorp=&amp;rft.date=20010314&amp;rft.volume=285&amp;rft.issue=10&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=1363&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0098-7484&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft.eisbn=&amp;rft_dat=&lt;gale_hrca>71838595&lt;/gale_hrca>&amp;rft_id=info:oai/>\"
-        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-09-18T23%3A42%3A08IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-wj&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer&rft.jtitle=Cancer&rft.btitle=&rft.aulast=Fulgoni&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Fulgoni%2C%20Victor%20L.&rft.aucorp=&rft.date=19981015&rft.volume=83&rft.issue=&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1775&rft.epage=1783&rft.pages=&rft.artnum=&rft.issn=0008-543X&rft.eissn=1097-0142&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1002/(SICI)1097-0142(19981015)83:8+%3C1775::AID-CNCR21%3E3.0.CO%3B2-Q&rft.eisbn=&rft_dat=<wj>AID-CNCR21%3E3.0.CO%3B2-Q</wj>&rft_id=info:oai/>]]></sear:openurl>\n
-        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-09-18T23%3A42%3A08IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-wj&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer&rft.jtitle=Cancer&rft.btitle=&rft.aulast=Fulgoni&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Fulgoni%2C%20Victor%20L.&rft.aucorp=&rft.date=19981015&rft.volume=83&rft.issue=&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1775&rft.epage=1783&rft.pages=&rft.artnum=&rft.issn=0008-543X&rft.eissn=1097-0142&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1002/(SICI)1097-0142(19981015)83:8+%3C1775::AID-CNCR21%3E3.0.CO%3B2-Q&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft.eisbn=&rft_dat=<wj>AID-CNCR21%3E3.0.CO%3B2-Q</wj>&rft_id=info:oai/>]]></sear:openurlfulltext>\n
+        \         <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A48IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A48IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A49IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A49IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Cancer.&amp;rft.jtitle=Nature&amp;rft.btitle=&amp;rft.aulast=&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Pulverer,%20Bernd&amp;rft.aucorp=&amp;rft.date=20010517&amp;rft.volume=411&amp;rft.issue=6835&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=335&amp;rft.epage=&amp;rft.pages=&amp;rft.artnum=&amp;rft.issn=0028-0836&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;gale_ofa>188005462&lt;/gale_ofa>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A48IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-wj&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer&rft.jtitle=Cancer&rft.btitle=&rft.aulast=Fulgoni&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Fulgoni,%20Victor%20L.&rft.aucorp=&rft.date=19981015&rft.volume=83&rft.issue=&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1775&rft.epage=1783&rft.pages=&rft.artnum=&rft.issn=0008-543X&rft.eissn=1097-0142&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1002/(SICI)1097-0142(19981015)83:8+<1775::AID-CNCR21>3.0.CO;2-Q&rft.object_id=&rft_dat=<wj>AID-CNCR21>3.0.CO;2-Q</wj>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A48IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-wj&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer&rft.jtitle=Cancer&rft.btitle=&rft.aulast=Fulgoni&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Fulgoni,%20Victor%20L.&rft.aucorp=&rft.date=19981015&rft.volume=83&rft.issue=&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1775&rft.epage=1783&rft.pages=&rft.artnum=&rft.issn=0008-543X&rft.eissn=1097-0142&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1002/(SICI)1097-0142(19981015)83:8+<1775::AID-CNCR21>3.0.CO;2-Q&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<wj>AID-CNCR21>3.0.CO;2-Q</wj>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A49IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-wj&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer&rft.jtitle=Cancer&rft.btitle=&rft.aulast=Fulgoni&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Fulgoni,%20Victor%20L.&rft.aucorp=&rft.date=19981015&rft.volume=83&rft.issue=&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1775&rft.epage=1783&rft.pages=&rft.artnum=&rft.issn=0008-543X&rft.eissn=1097-0142&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1002/(SICI)1097-0142(19981015)83:8+<1775::AID-CNCR21>3.0.CO;2-Q&rft.object_id=&rft_dat=<wj>AID-CNCR21>3.0.CO;2-Q</wj>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A49IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-wj&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Cancer&rft.jtitle=Cancer&rft.btitle=&rft.aulast=Fulgoni&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Fulgoni,%20Victor%20L.&rft.aucorp=&rft.date=19981015&rft.volume=83&rft.issue=&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1775&rft.epage=1783&rft.pages=&rft.artnum=&rft.issn=0008-543X&rft.eissn=1097-0142&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1002/(SICI)1097-0142(19981015)83:8+<1775::AID-CNCR21>3.0.CO;2-Q&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<wj>AID-CNCR21>3.0.CO;2-Q</wj>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
         \         </sear:LINKS>\n        </sear:DOC>\n      </sear:DOCSET>\n    </sear:RESULT>\n
-        \   <sear:searchToken>0</sear:searchToken>\n  </sear:JAGROOT>\n</sear:SEGMENTS>\n"
+        \ </sear:JAGROOT>\n</sear:SEGMENTS>\n"
     http_version: 
-  recorded_at: Wed, 19 Sep 2012 04:42:08 GMT
-recorded_with: VCR 2.2.5
+  recorded_at: Tue, 07 May 2013 03:20:52 GMT
+recorded_with: VCR 2.4.0

--- a/test/vcr_cassettes/primo/search_smoke_test.yml
+++ b/test/vcr_cassettes/primo/search_smoke_test.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://example.org/PrimoWebServices/xservice/search/brief?bulkSize=10&highlight=true&institution=DUMMY_INSTITUTION&lang=eng&loc=adaptor,primo_central_multiple_fe&onCampus=false&query=any,contains,globalization%20from%20below
+    uri: http://example.org/PrimoWebServices/xservice/search/brief?bulkSize=10&highlight=true&indx=1&institution=DUMMY_INSTITUTION&lang=eng&loc=adaptor,primo_central_multiple_fe&onCampus=false&query=any,contains,globalization%20from%20below
     body:
       encoding: US-ASCII
       string: ''
@@ -13,12 +13,10 @@ http_interactions:
       message: !binary |-
         T0s=
     headers:
-      !binary "U2VydmVy":
-      - !binary |-
-        QXBhY2hlLUNveW90ZS8xLjE=
       !binary "WC1Qb3dlcmVkLUJ5":
       - !binary |-
-        U2VydmxldCAyLjU7IEpCb3NzLTUuMC9KQm9zc1dlYi0yLjE=
+        U2VydmxldCAyLjQ7IFRvbWNhdC01LjAuMjgvSkJvc3MtNC4wLjEgKGJ1aWxk
+        OiBDVlNUYWc9SkJvc3NfNF8wXzEgZGF0ZT0yMDA0MTIyMzA5NDQp
       !binary "Q29udGVudC1UeXBl":
       - !binary |-
         dGV4dC94bWw7Y2hhcnNldD1VVEYtOA==
@@ -27,171 +25,163 @@ http_interactions:
         Y2h1bmtlZA==
       !binary "RGF0ZQ==":
       - !binary |-
-        TW9uLCAyMCBBdWcgMjAxMiAyMDo1NDo0NSBHTVQ=
+        VHVlLCAwNyBNYXkgMjAxMyAwMzoyMDo0OSBHTVQ=
+      !binary "U2VydmVy":
+      - !binary |-
+        QXBhY2hlLUNveW90ZS8xLjE=
     body:
       encoding: UTF-8
-      string: ! "<sear:SEGMENTS xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
-        xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\" xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\">\n
-        \ <sear:JAGROOT>\n    <sear:RESULT>\n      <sear:QUERYTRANSFORMS/>\n      <sear:FACETLIST
-        ACCURATE_COUNTERS=\"true\">\n        <sear:FACET COUNT=\"20\" NAME=\"creator\">\n
-        \         <sear:FACET_VALUES VALUE=\"5\" KEY=\"Smith, J.\"/>\n          <sear:FACET_VALUES
-        VALUE=\"3\" KEY=\"Carr, Barry\"/>\n          <sear:FACET_VALUES VALUE=\"1\"
-        KEY=\"Dellacioppa, Kara\"/>\n          <sear:FACET_VALUES VALUE=\"2\" KEY=\"Tubajon,
-        Gina\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"Scipes, K.\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"1\" KEY=\"Carr, B\"/>\n          <sear:FACET_VALUES
-        VALUE=\"3\" KEY=\"Smith, Brendan\"/>\n          <sear:FACET_VALUES VALUE=\"6\"
-        KEY=\"Costello, Tim\"/>\n          <sear:FACET_VALUES VALUE=\"5\" KEY=\"Turner,
-        Terisa E.\"/>\n          <sear:FACET_VALUES VALUE=\"2\" KEY=\"Chase-dunn,
-        Christopher\"/>\n          <sear:FACET_VALUES VALUE=\"7\" KEY=\"Brecher, Jeremy\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"7\" KEY=\"Brownhill, Leigh S.\"/>\n          <sear:FACET_VALUES
-        VALUE=\"3\" KEY=\"Ribeiro, Gustavo Lins\"/>\n          <sear:FACET_VALUES
-        VALUE=\"1\" KEY=\"Roberts, BR\"/>\n          <sear:FACET_VALUES VALUE=\"1\"
-        KEY=\"Wayland, SV\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"Hernández
-        Castillo, R. aída\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"Jones,
-        Sarah Lynn\"/>\n          <sear:FACET_VALUES VALUE=\"2\" KEY=\"Zaman, Habiba\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"1\" KEY=\"Sally Engle Merry, Mihaela
-        Serban Rosen, Peggy Levitt\"/>\n          <sear:FACET_VALUES VALUE=\"4\" KEY=\"Fullerton,
-        Andrew S.\"/>\n        </sear:FACET>\n        <sear:FACET COUNT=\"1\" NAME=\"lcc\">\n
-        \         <sear:FACET_VALUES VALUE=\"16\" KEY=\"H - Social sciences.\"/>\n
-        \       </sear:FACET>\n        <sear:FACET COUNT=\"15\" NAME=\"lang\">\n          <sear:FACET_VALUES
-        VALUE=\"1\" KEY=\"lit\"/>\n          <sear:FACET_VALUES VALUE=\"17\" KEY=\"한국어\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"131\" KEY=\"ger\"/>\n          <sear:FACET_VALUES
-        VALUE=\"14\" KEY=\"por\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"tur\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"44\" KEY=\"fre\"/>\n          <sear:FACET_VALUES
-        VALUE=\"1\" KEY=\"heb\"/>\n          <sear:FACET_VALUES VALUE=\"3\" KEY=\"kor\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"11\" KEY=\"chi\"/>\n          <sear:FACET_VALUES
-        VALUE=\"1\" KEY=\"ita\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"rus\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"1\" KEY=\"dut\"/>\n          <sear:FACET_VALUES
-        VALUE=\"1\" KEY=\"jpn\"/>\n          <sear:FACET_VALUES VALUE=\"54214\" KEY=\"eng\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"117\" KEY=\"spa\"/>\n        </sear:FACET>\n
-        \       <sear:FACET COUNT=\"13\" NAME=\"rtype\">\n          <sear:FACET_VALUES
-        VALUE=\"6069\" KEY=\"books\"/>\n          <sear:FACET_VALUES VALUE=\"3051\"
-        KEY=\"reviews\"/>\n          <sear:FACET_VALUES VALUE=\"61635\" KEY=\"articles\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"26\" KEY=\"other\"/>\n          <sear:FACET_VALUES
-        VALUE=\"2\" KEY=\"journals\"/>\n          <sear:FACET_VALUES VALUE=\"2315\"
-        KEY=\"text_resources\"/>\n          <sear:FACET_VALUES VALUE=\"11\" KEY=\"websites\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"12363\" KEY=\"newspaper_articles\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"717\" KEY=\"legal_documents\"/>\n          <sear:FACET_VALUES
-        VALUE=\"1827\" KEY=\"reference_entrys\"/>\n          <sear:FACET_VALUES VALUE=\"55\"
-        KEY=\"Dissertations\"/>\n          <sear:FACET_VALUES VALUE=\"390\" KEY=\"conference_proceedings\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"66\" KEY=\"media\"/>\n        </sear:FACET>\n
-        \       <sear:FACET COUNT=\"19\" NAME=\"topic\">\n          <sear:FACET_VALUES
-        VALUE=\"5\" KEY=\"Native South Americans\"/>\n          <sear:FACET_VALUES
-        VALUE=\"576\" KEY=\"International Economic Relations\"/>\n          <sear:FACET_VALUES
-        VALUE=\"215\" KEY=\"Neoliberalism\"/>\n          <sear:FACET_VALUES VALUE=\"4944\"
-        KEY=\" International Trade Law\"/>\n          <sear:FACET_VALUES VALUE=\"39\"
-        KEY=\"Multicultural Education\"/>\n          <sear:FACET_VALUES VALUE=\"160\"
-        KEY=\"Transnationalism\"/>\n          <sear:FACET_VALUES VALUE=\"125\" KEY=\"Social
-        Movements\"/>\n          <sear:FACET_VALUES VALUE=\"2\" KEY=\"라푸라푸 유출사고\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"2644\" KEY=\" Criminal Law &amp; Procedure\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"761\" KEY=\" Organizations\"/>\n          <sear:FACET_VALUES
-        VALUE=\"163\" KEY=\"Internationalization\"/>\n          <sear:FACET_VALUES
-        VALUE=\"47\" KEY=\"Electronic Books\"/>\n          <sear:FACET_VALUES VALUE=\"292\"
-        KEY=\"Foreign Countries\"/>\n          <sear:FACET_VALUES VALUE=\"399\" KEY=\"History\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"3798\" KEY=\" International\"/>\n          <sear:FACET_VALUES
-        VALUE=\"3432\" KEY=\" Globalization\"/>\n          <sear:FACET_VALUES VALUE=\"313\"
-        KEY=\"Capitalism\"/>\n          <sear:FACET_VALUES VALUE=\"145\" KEY=\"Feminism\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"10\" KEY=\" globalization from below\"/>\n
-        \       </sear:FACET>\n        <sear:FACET COUNT=\"2\" NAME=\"tlevel\">\n
-        \         <sear:FACET_VALUES VALUE=\"73103\" KEY=\"online_resources\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"48801\" KEY=\"peer_reviewed\"/>\n        </sear:FACET>\n
-        \       <sear:FACET COUNT=\"11\" NAME=\"pfilter\">\n          <sear:FACET_VALUES
-        VALUE=\"717\" KEY=\"legal_documents\"/>\n          <sear:FACET_VALUES VALUE=\"6080\"
-        KEY=\"books\"/>\n          <sear:FACET_VALUES VALUE=\"3051\" KEY=\"reviews\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"1827\" KEY=\"reference_entrys\"/>\n          <sear:FACET_VALUES
-        VALUE=\"2\" KEY=\"journals\"/>\n          <sear:FACET_VALUES VALUE=\"63786\"
-        KEY=\"articles\"/>\n          <sear:FACET_VALUES VALUE=\"55\" KEY=\"Dissertations\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"66\" KEY=\"audio_video\"/>\n          <sear:FACET_VALUES
-        VALUE=\"390\" KEY=\"conference_proceedings\"/>\n          <sear:FACET_VALUES
-        VALUE=\"11\" KEY=\"websites\"/>\n          <sear:FACET_VALUES VALUE=\"12363\"
-        KEY=\"newspaper_articles\"/>\n        </sear:FACET>\n        <sear:FACET COUNT=\"53\"
-        NAME=\"creationdate\">\n          <sear:FACET_VALUES VALUE=\"8060\" KEY=\"2008\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"8134\" KEY=\"2009\"/>\n          <sear:FACET_VALUES
-        VALUE=\"7054\" KEY=\"2006\"/>\n          <sear:FACET_VALUES VALUE=\"7579\"
-        KEY=\"2007\"/>\n          <sear:FACET_VALUES VALUE=\"5489\" KEY=\"2004\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"6290\" KEY=\"2005\"/>\n          <sear:FACET_VALUES
-        VALUE=\"4266\" KEY=\"2002\"/>\n          <sear:FACET_VALUES VALUE=\"4943\"
-        KEY=\"2003\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"1930\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"3\" KEY=\"1970\"/>\n          <sear:FACET_VALUES
-        VALUE=\"1\" KEY=\"1971\"/>\n          <sear:FACET_VALUES VALUE=\"2\" KEY=\"1973\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"4\" KEY=\"1974\"/>\n          <sear:FACET_VALUES
-        VALUE=\"3\" KEY=\"1975\"/>\n          <sear:FACET_VALUES VALUE=\"2\" KEY=\"1976\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"4119\" KEY=\"2012\"/>\n          <sear:FACET_VALUES
-        VALUE=\"2\" KEY=\"1977\"/>\n          <sear:FACET_VALUES VALUE=\"6831\" KEY=\"2011\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"8\" KEY=\"1978\"/>\n          <sear:FACET_VALUES
-        VALUE=\"7864\" KEY=\"2010\"/>\n          <sear:FACET_VALUES VALUE=\"6\" KEY=\"1979\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"196\" KEY=\"1990\"/>\n          <sear:FACET_VALUES
-        VALUE=\"2\" KEY=\"1940\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"500\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"10\" KEY=\"1982\"/>\n          <sear:FACET_VALUES
-        VALUE=\"10\" KEY=\"1983\"/>\n          <sear:FACET_VALUES VALUE=\"3\" KEY=\"1980\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"4\" KEY=\"1981\"/>\n          <sear:FACET_VALUES
-        VALUE=\"46\" KEY=\"1986\"/>\n          <sear:FACET_VALUES VALUE=\"52\" KEY=\"1987\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"10\" KEY=\"1984\"/>\n          <sear:FACET_VALUES
-        VALUE=\"18\" KEY=\"1985\"/>\n          <sear:FACET_VALUES VALUE=\"62\" KEY=\"1988\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"125\" KEY=\"1989\"/>\n          <sear:FACET_VALUES
-        VALUE=\"1\" KEY=\"1959\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"1957\"/>\n
+      string: ! "<sear:SEGMENTS xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
+        xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n
+        \ <sear:JAGROOT>\n    <sear:RESULT>\n      <sear:FACETLIST ACCURATE_COUNTERS=\"true\">\n
+        \       <sear:FACET COUNT=\"20\" NAME=\"creator\">\n          <sear:FACET_VALUES
+        VALUE=\"2\" KEY=\"Ganesh, Shiv\"/>\n          <sear:FACET_VALUES VALUE=\"3\"
+        KEY=\"Bergh, Andreas\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"Eckhardt,
+        Rose\"/>\n          <sear:FACET_VALUES VALUE=\"8\" KEY=\"Brecher, Jeremy\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"3\" KEY=\"Mendieta, Eduardo\"/>\n          <sear:FACET_VALUES
+        VALUE=\"3\" KEY=\"Steyaert, Chris\"/>\n          <sear:FACET_VALUES VALUE=\"2\"
+        KEY=\"Schoonmaker, Sara\"/>\n          <sear:FACET_VALUES VALUE=\"2\" KEY=\"Watson,
+        Hilbourne A.\"/>\n          <sear:FACET_VALUES VALUE=\"2\" KEY=\"Johnson,
+        Alice K.\"/>\n          <sear:FACET_VALUES VALUE=\"2\" KEY=\"Price, Marie
+        D.\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"Buckeridge, David L.\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"46\" KEY=\"Boli, John\"/>\n          <sear:FACET_VALUES
+        VALUE=\"3\" KEY=\"Lee, Ezra Yoo - Hyeok\"/>\n          <sear:FACET_VALUES
+        VALUE=\"4\" KEY=\"Gotham, Kevin Fox\"/>\n          <sear:FACET_VALUES VALUE=\"1\"
+        KEY=\"Sparke, Matthew\"/>\n          <sear:FACET_VALUES VALUE=\"2\" KEY=\"Zoller,
+        Heather\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"Anguelov, Dimitar\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"4\" KEY=\"Pillai, Dylan R.\"/>\n          <sear:FACET_VALUES
+        VALUE=\"2\" KEY=\"Gandin, Luis Armando\"/>\n          <sear:FACET_VALUES VALUE=\"2\"
+        KEY=\"Cheney, George\"/>\n        </sear:FACET>\n        <sear:FACET COUNT=\"1\"
+        NAME=\"lcc\">\n          <sear:FACET_VALUES VALUE=\"285\" KEY=\"H - Social
+        sciences.\"/>\n        </sear:FACET>\n        <sear:FACET COUNT=\"11\" NAME=\"lang\">\n
+        \         <sear:FACET_VALUES VALUE=\"4\" KEY=\"lit\"/>\n          <sear:FACET_VALUES
+        VALUE=\"19\" KEY=\"한국어\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"rus\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"94\" KEY=\"ger\"/>\n          <sear:FACET_VALUES
+        VALUE=\"7\" KEY=\"chi\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"jpn\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"1\" KEY=\"fin\"/>\n          <sear:FACET_VALUES
+        VALUE=\"41997\" KEY=\"eng\"/>\n          <sear:FACET_VALUES VALUE=\"63\" KEY=\"fre\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"2\" KEY=\"swe\"/>\n          <sear:FACET_VALUES
+        VALUE=\"145\" KEY=\"spa\"/>\n        </sear:FACET>\n        <sear:FACET COUNT=\"12\"
+        NAME=\"rtype\">\n          <sear:FACET_VALUES VALUE=\"2036\" KEY=\"books\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"5944\" KEY=\"reviews\"/>\n          <sear:FACET_VALUES
+        VALUE=\"18\" KEY=\"reference_entrys\"/>\n          <sear:FACET_VALUES VALUE=\"1\"
+        KEY=\"journals\"/>\n          <sear:FACET_VALUES VALUE=\"2\" KEY=\"dissertations\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"15\" KEY=\"other\"/>\n          <sear:FACET_VALUES
+        VALUE=\"49935\" KEY=\"articles\"/>\n          <sear:FACET_VALUES VALUE=\"1529\"
+        KEY=\"text_resources\"/>\n          <sear:FACET_VALUES VALUE=\"2156\" KEY=\"conference_proceedings\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"3\" KEY=\"websites\"/>\n          <sear:FACET_VALUES
+        VALUE=\"105\" KEY=\"media\"/>\n          <sear:FACET_VALUES VALUE=\"3066\"
+        KEY=\"newspaper_articles\"/>\n        </sear:FACET>\n        <sear:FACET COUNT=\"19\"
+        NAME=\"topic\">\n          <sear:FACET_VALUES VALUE=\"1349\" KEY=\"articles\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"293\" KEY=\"Multiculturalism\"/>\n          <sear:FACET_VALUES
+        VALUE=\"269\" KEY=\"Neoliberalism\"/>\n          <sear:FACET_VALUES VALUE=\"845\"
+        KEY=\"Economic Development\"/>\n          <sear:FACET_VALUES VALUE=\"34\"
+        KEY=\"Malaria\"/>\n          <sear:FACET_VALUES VALUE=\"189\" KEY=\"Transnationalism\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"136\" KEY=\"Social Movements\"/>\n          <sear:FACET_VALUES
+        VALUE=\"33\" KEY=\"Imagination\"/>\n          <sear:FACET_VALUES VALUE=\"49\"
+        KEY=\"Resistance\"/>\n          <sear:FACET_VALUES VALUE=\"304\" KEY=\"Global
+        Economy\"/>\n          <sear:FACET_VALUES VALUE=\"3646\" KEY=\" Globalization\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"118\" KEY=\"Inequality\"/>\n          <sear:FACET_VALUES
+        VALUE=\"38\" KEY=\"Anti-globalization Movement\"/>\n          <sear:FACET_VALUES
+        VALUE=\"2\" KEY=\"Critical Studies\"/>\n          <sear:FACET_VALUES VALUE=\"71\"
+        KEY=\"Literacy\"/>\n          <sear:FACET_VALUES VALUE=\"9\" KEY=\" globalization
+        from below\"/>\n          <sear:FACET_VALUES VALUE=\"550\" KEY=\"Human Rights\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"8\" KEY=\"Politics Of Scale\"/>\n          <sear:FACET_VALUES
+        VALUE=\"428\" KEY=\"Internet\"/>\n        </sear:FACET>\n        <sear:FACET
+        COUNT=\"2\" NAME=\"tlevel\">\n          <sear:FACET_VALUES VALUE=\"50824\"
+        KEY=\"online_resources\"/>\n          <sear:FACET_VALUES VALUE=\"41333\" KEY=\"peer_reviewed\"/>\n
+        \       </sear:FACET>\n        <sear:FACET COUNT=\"10\" NAME=\"pfilter\">\n
+        \         <sear:FACET_VALUES VALUE=\"2040\" KEY=\"books\"/>\n          <sear:FACET_VALUES
+        VALUE=\"5944\" KEY=\"reviews\"/>\n          <sear:FACET_VALUES VALUE=\"18\"
+        KEY=\"reference_entrys\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"journals\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"2\" KEY=\"dissertations\"/>\n          <sear:FACET_VALUES
+        VALUE=\"50907\" KEY=\"articles\"/>\n          <sear:FACET_VALUES VALUE=\"105\"
+        KEY=\"audio_video\"/>\n          <sear:FACET_VALUES VALUE=\"2156\" KEY=\"conference_proceedings\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"3\" KEY=\"websites\"/>\n          <sear:FACET_VALUES
+        VALUE=\"3066\" KEY=\"newspaper_articles\"/>\n        </sear:FACET>\n        <sear:FACET
+        COUNT=\"52\" NAME=\"creationdate\">\n          <sear:FACET_VALUES VALUE=\"5016\"
+        KEY=\"2008\"/>\n          <sear:FACET_VALUES VALUE=\"5166\" KEY=\"2009\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"4089\" KEY=\"2006\"/>\n          <sear:FACET_VALUES
+        VALUE=\"4571\" KEY=\"2007\"/>\n          <sear:FACET_VALUES VALUE=\"3087\"
+        KEY=\"2004\"/>\n          <sear:FACET_VALUES VALUE=\"3479\" KEY=\"2005\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"2815\" KEY=\"2002\"/>\n          <sear:FACET_VALUES
+        VALUE=\"2941\" KEY=\"2003\"/>\n          <sear:FACET_VALUES VALUE=\"3\" KEY=\"1970\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"1\" KEY=\"1971\"/>\n          <sear:FACET_VALUES
+        VALUE=\"2\" KEY=\"1973\"/>\n          <sear:FACET_VALUES VALUE=\"2\" KEY=\"1974\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"3\" KEY=\"1975\"/>\n          <sear:FACET_VALUES
+        VALUE=\"2\" KEY=\"1976\"/>\n          <sear:FACET_VALUES VALUE=\"6107\" KEY=\"2012\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"1\" KEY=\"1977\"/>\n          <sear:FACET_VALUES
+        VALUE=\"5397\" KEY=\"2011\"/>\n          <sear:FACET_VALUES VALUE=\"7\" KEY=\"1978\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"5643\" KEY=\"2010\"/>\n          <sear:FACET_VALUES
+        VALUE=\"6\" KEY=\"1979\"/>\n          <sear:FACET_VALUES VALUE=\"1008\" KEY=\"2013\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"132\" KEY=\"1990\"/>\n          <sear:FACET_VALUES
+        VALUE=\"1\" KEY=\"1940\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"500\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"8\" KEY=\"1982\"/>\n          <sear:FACET_VALUES
+        VALUE=\"10\" KEY=\"1983\"/>\n          <sear:FACET_VALUES VALUE=\"28\" KEY=\"1\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"4\" KEY=\"1980\"/>\n          <sear:FACET_VALUES
+        VALUE=\"4\" KEY=\"1981\"/>\n          <sear:FACET_VALUES VALUE=\"32\" KEY=\"1986\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"37\" KEY=\"1987\"/>\n          <sear:FACET_VALUES
+        VALUE=\"9\" KEY=\"1984\"/>\n          <sear:FACET_VALUES VALUE=\"16\" KEY=\"1985\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"42\" KEY=\"1988\"/>\n          <sear:FACET_VALUES
+        VALUE=\"84\" KEY=\"1989\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"1959\"/>\n
         \         <sear:FACET_VALUES VALUE=\"1\" KEY=\"1952\"/>\n          <sear:FACET_VALUES
-        VALUE=\"648\" KEY=\"1995\"/>\n          <sear:FACET_VALUES VALUE=\"865\" KEY=\"1996\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"1136\" KEY=\"1997\"/>\n          <sear:FACET_VALUES
-        VALUE=\"1547\" KEY=\"1998\"/>\n          <sear:FACET_VALUES VALUE=\"217\"
-        KEY=\"1991\"/>\n          <sear:FACET_VALUES VALUE=\"250\" KEY=\"1992\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"367\" KEY=\"1993\"/>\n          <sear:FACET_VALUES
-        VALUE=\"504\" KEY=\"1994\"/>\n          <sear:FACET_VALUES VALUE=\"2086\"
+        VALUE=\"545\" KEY=\"1995\"/>\n          <sear:FACET_VALUES VALUE=\"729\" KEY=\"1996\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"970\" KEY=\"1997\"/>\n          <sear:FACET_VALUES
+        VALUE=\"1290\" KEY=\"1998\"/>\n          <sear:FACET_VALUES VALUE=\"139\"
+        KEY=\"1991\"/>\n          <sear:FACET_VALUES VALUE=\"177\" KEY=\"1992\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"273\" KEY=\"1993\"/>\n          <sear:FACET_VALUES
+        VALUE=\"411\" KEY=\"1994\"/>\n          <sear:FACET_VALUES VALUE=\"1477\"
         KEY=\"1999\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"1966\"/>\n
         \         <sear:FACET_VALUES VALUE=\"1\" KEY=\"1969\"/>\n          <sear:FACET_VALUES
-        VALUE=\"1\" KEY=\"1968\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"1963\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"1\" KEY=\"1964\"/>\n          <sear:FACET_VALUES
-        VALUE=\"3693\" KEY=\"2001\"/>\n          <sear:FACET_VALUES VALUE=\"3361\"
-        KEY=\"2000\"/>\n        </sear:FACET>\n        <sear:FACET COUNT=\"20\" NAME=\"domain\">\n
-        \         <sear:FACET_VALUES VALUE=\"11\" KEY=\"HathiTrust Digital Library\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"4\" KEY=\"NARCIS (Royal Netherlands Academy
-        of Arts and Sciences)\"/>\n          <sear:FACET_VALUES VALUE=\"44\" KEY=\"ebrary
-        Books\"/>\n          <sear:FACET_VALUES VALUE=\"18\" KEY=\"DBpia Articles\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"17\" KEY=\"Wiley Online Library\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"514\" KEY=\"ERIC (U.S. Dept. of Education)\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"10169\" KEY=\"SciVerse ScienceDirect
-        (Elsevier)\"/>\n          <sear:FACET_VALUES VALUE=\"3\" KEY=\"Dialnet\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"3025\" KEY=\"Arts &amp; Sciences (JSTOR)\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"1658\" KEY=\"Oxford Journals (Oxford
-        University Press)\"/>\n          <sear:FACET_VALUES VALUE=\"970\" KEY=\"SciVerse
-        ScienceDirect Books (Elsevier)\"/>\n          <sear:FACET_VALUES VALUE=\"150\"
-        KEY=\"Informa - Taylor &amp; Francis (CrossRef)\"/>\n          <sear:FACET_VALUES
-        VALUE=\"54\" KEY=\"Ebook Library (EBL) (Ebooks Corp.)\"/>\n          <sear:FACET_VALUES
-        VALUE=\"1\" KEY=\"CLEO Revues.org (CrossRef)\"/>\n          <sear:FACET_VALUES
-        VALUE=\"9507\" KEY=\"Academic Law Reviews (LexisNexis)\"/>\n          <sear:FACET_VALUES
-        VALUE=\"1173\" KEY=\"University of Chicago Press Journals\"/>\n          <sear:FACET_VALUES
-        VALUE=\"304\" KEY=\"Sage Publications (CrossRef)\"/>\n          <sear:FACET_VALUES
-        VALUE=\"8\" KEY=\"KISS (Korean studies Information Service System)\"/>\n          <sear:FACET_VALUES
-        VALUE=\"2875\" KEY=\"Cambridge Journals Online (Cambridge University Press)\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"38398\" KEY=\"OneFile (GALE)\"/>\n        </sear:FACET>\n
-        \       <sear:FACET COUNT=\"20\" NAME=\"jtitle\">\n          <sear:FACET_VALUES
-        VALUE=\"2\" KEY=\"공간과 사회\"/>\n          <sear:FACET_VALUES VALUE=\"2\" KEY=\"Lien
-        Social Et Politiques\"/>\n          <sear:FACET_VALUES VALUE=\"5\" KEY=\"Cosmos
-        and History: The Journal of Natural and Social Philosophy\"/>\n          <sear:FACET_VALUES
-        VALUE=\"2\" KEY=\"Canadian Journal of Development Studies\"/>\n          <sear:FACET_VALUES
-        VALUE=\"102\" KEY=\"Journal of World Business\"/>\n          <sear:FACET_VALUES
-        VALUE=\"8\" KEY=\"CHOICE: Current Reviews for Academic Libraries\"/>\n          <sear:FACET_VALUES
-        VALUE=\"1\" KEY=\"Avances en supervisión educativa: Revista de la Asociación
-        de Inspectores de Educación de España\"/>\n          <sear:FACET_VALUES VALUE=\"343\"
-        KEY=\"The New York Times\"/>\n          <sear:FACET_VALUES VALUE=\"42\" KEY=\"International
-        Labor And Working-class History\"/>\n          <sear:FACET_VALUES VALUE=\"1\"
-        KEY=\"City\"/>\n          <sear:FACET_VALUES VALUE=\"4\" KEY=\"International
-        Social Science Journal\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"Educational
-        Theory\"/>\n          <sear:FACET_VALUES VALUE=\"2\" KEY=\"Progress In Development
-        Studies\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"Economy And Society\"/>\n
-        \         <sear:FACET_VALUES VALUE=\"2\" KEY=\"Canadian Journal Of Development
-        Studies/revue Canadienne D'études Du Développement\"/>\n          <sear:FACET_VALUES
-        VALUE=\"1\" KEY=\"담론201\"/>\n          <sear:FACET_VALUES VALUE=\"99\" KEY=\"Annals
-        Of The American Academy Of Political And Social Science\"/>\n          <sear:FACET_VALUES
-        VALUE=\"2\" KEY=\"Contemporary Sociology: A Journal Of Reviews\"/>\n          <sear:FACET_VALUES
-        VALUE=\"70\" KEY=\"The Nation\"/>\n          <sear:FACET_VALUES VALUE=\"3\"
-        KEY=\"International Journal of Urban and Regional Research\"/>\n        </sear:FACET>\n
-        \     </sear:FACETLIST>\n      <sear:DOCSET TOTAL_TIME=\"1341\" LASTHIT=\"9\"
-        FIRSTHIT=\"0\" TOTALHITS=\"86908\" HIT_TIME=\"1202\">\n        <sear:DOC LOCAL=\"false\"
-        SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
-        NO=\"1\" RANK=\"0.07413188\" ID=\"185747255\">\n          <prim:PrimoNMBib
-        xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n
-        \           <prim:record>\n              <prim:control>\n                <prim:sourcerecordid>S1090-9516(10)00042-8</prim:sourcerecordid>\n
+        VALUE=\"1\" KEY=\"1968\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"1964\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"2379\" KEY=\"2001\"/>\n          <sear:FACET_VALUES
+        VALUE=\"2190\" KEY=\"2000\"/>\n        </sear:FACET>\n        <sear:FACET
+        COUNT=\"20\" NAME=\"domain\">\n          <sear:FACET_VALUES VALUE=\"20\" KEY=\"DBpia
+        Articles\"/>\n          <sear:FACET_VALUES VALUE=\"2862\" KEY=\"Literature
+        Resource Center (Gale)\"/>\n          <sear:FACET_VALUES VALUE=\"2097\" KEY=\"SAGE
+        Journals\"/>\n          <sear:FACET_VALUES VALUE=\"972\" KEY=\"Wiley Online
+        Library\"/>\n          <sear:FACET_VALUES VALUE=\"1218\" KEY=\"ERIC (U.S.
+        Dept. of Education)\"/>\n          <sear:FACET_VALUES VALUE=\"3753\" KEY=\"Project
+        MUSE\"/>\n          <sear:FACET_VALUES VALUE=\"8438\" KEY=\"SciVerse ScienceDirect
+        (Elsevier)\"/>\n          <sear:FACET_VALUES VALUE=\"5924\" KEY=\"Arts &amp;
+        Sciences (JSTOR)\"/>\n          <sear:FACET_VALUES VALUE=\"1961\" KEY=\"SpringerLink\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"1168\" KEY=\"Oxford Journals (Oxford
+        University Press)\"/>\n          <sear:FACET_VALUES VALUE=\"56\" KEY=\"Digital
+        Commons (Bepress)\"/>\n          <sear:FACET_VALUES VALUE=\"458\" KEY=\"Informa
+        - Taylor &amp; Francis (CrossRef)\"/>\n          <sear:FACET_VALUES VALUE=\"1993\"
+        KEY=\"MEDLINE (NLM)\"/>\n          <sear:FACET_VALUES VALUE=\"1\" KEY=\"CLEO
+        Revues.org (CrossRef)\"/>\n          <sear:FACET_VALUES VALUE=\"9166\" KEY=\"Academic
+        Law Reviews (LexisNexis)\"/>\n          <sear:FACET_VALUES VALUE=\"629\" KEY=\"Directory
+        of Open Access Journals (DOAJ)\"/>\n          <sear:FACET_VALUES VALUE=\"1758\"
+        KEY=\"University of Chicago Press Journals\"/>\n          <sear:FACET_VALUES
+        VALUE=\"7\" KEY=\"KISS (Korean studies Information Service System)\"/>\n          <sear:FACET_VALUES
+        VALUE=\"219\" KEY=\"Language &amp; Literature (JSTOR)\"/>\n          <sear:FACET_VALUES
+        VALUE=\"30599\" KEY=\"OneFile (GALE)\"/>\n        </sear:FACET>\n        <sear:FACET
+        COUNT=\"18\" NAME=\"jtitle\">\n          <sear:FACET_VALUES VALUE=\"37\" KEY=\"CLCWeb:
+        Comparative Literature and Culture\"/>\n          <sear:FACET_VALUES VALUE=\"13\"
+        KEY=\"Emerging Infectious Diseases\"/>\n          <sear:FACET_VALUES VALUE=\"25\"
+        KEY=\"Sociology\"/>\n          <sear:FACET_VALUES VALUE=\"2\" KEY=\"Area\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"3\" KEY=\"Law &amp; Society Review\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"281\" KEY=\"World Development\"/>\n          <sear:FACET_VALUES
+        VALUE=\"5\" KEY=\"International Journal Of Urban And Regional Research\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"3\" KEY=\"City\"/>\n          <sear:FACET_VALUES
+        VALUE=\"4\" KEY=\"International Social Science Journal\"/>\n          <sear:FACET_VALUES
+        VALUE=\"2\" KEY=\"Discourse: Studies in the Cultural Politics of Education\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"15\" KEY=\"Journal of Social Work Education\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"31\" KEY=\"Social Science Research\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"2\" KEY=\"Communication Monographs\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"4\" KEY=\"Development and Change\"/>\n
+        \         <sear:FACET_VALUES VALUE=\"112\" KEY=\"Annals Of The American Academy
+        Of Political And Social Science\"/>\n          <sear:FACET_VALUES VALUE=\"29\"
+        KEY=\"Latin American Perspectives\"/>\n          <sear:FACET_VALUES VALUE=\"72\"
+        KEY=\"Human Rights Quarterly\"/>\n          <sear:FACET_VALUES VALUE=\"66\"
+        KEY=\"Signs\"/>\n        </sear:FACET>\n      </sear:FACETLIST>\n      <sear:DOCSET
+        TOTAL_TIME=\"659\" LASTHIT=\"10\" FIRSTHIT=\"1\" TOTALHITS=\"59203\" HIT_TIME=\"492\">\n
+        \       <sear:DOC LOCAL=\"false\" SEARCH_ENGINE_TYPE=\"Primo Central Search
+        Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\" NO=\"1\" RANK=\"0.07432991\"
+        ID=\"374630582\">\n          <prim:PrimoNMBib xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
+        xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n            <prim:record>\n
+        \             <prim:control>\n                <prim:sourcerecordid>S1090-9516(10)00042-8</prim:sourcerecordid>\n
         \               <prim:sourceid>sciversesciencedirect_elsevier</prim:sourceid>\n
         \               <prim:recordid>TN_sciversesciencedirect_elsevierS1090-9516(10)00042-8</prim:recordid>\n
         \               <prim:sourcesystem>Other</prim:sourcesystem>\n              </prim:control>\n
@@ -218,12 +208,15 @@ http_interactions:
         that cross a specific organizational space is discursively mediated.</prim:description>\n
         \               <prim:language>eng</prim:language>\n                <prim:source>SciVerse
         ScienceDirect Journals</prim:source>\n                <prim:lds50>peer_reviewed</prim:lds50>\n
-        \               <prim:version>3</prim:version>\n                <prim:snippetfield>description</prim:snippetfield>\n
-        \               <prim:snippet><![CDATA[the rise of English alters the discursive
-        negotiation in two different organizational contexts. Inspired by Appadurai's
-        understanding of “<span class=\"searchword\">globalization</span> <span class=\"searchword\">from</span>
-        <span class=\"searchword\">below</span>”, we suggest the term linguascape]]></prim:snippet>\n
-        \             </prim:display>\n              <prim:links>\n                <prim:openurl>$$Topenurl_article</prim:openurl>\n
+        \               <prim:version>5</prim:version>\n                <prim:snippetfield>subject</prim:snippetfield>\n
+        \               <prim:snippetfield>description</prim:snippetfield>\n                <prim:snippet><![CDATA[<span
+        class=\"searchword\">Globalization</span> <span class=\"searchword\">From</span>
+        <span class=\"searchword\">Below</span>...  the rise of English alters the
+        discursive negotiation in two different organizational contexts. Inspired
+        by Appadurai's understanding of “<span class=\"searchword\">globalization</span>
+        <span class=\"searchword\">from</span> <span class=\"searchword\">below</span>”,
+        we suggest the term linguascape]]></prim:snippet>\n              </prim:display>\n
+        \             <prim:links>\n                <prim:openurl>$$Topenurl_article</prim:openurl>\n
         \               <prim:backlink>$$Uhttp://dx.doi.org/10.1016/j.jwb.2010.07.003$$EView_record_in_SciVerse_ScienceDirect
         _Journals_(Elsevier)</prim:backlink>\n                <prim:openurlfulltext>$$Topenurlfull_article</prim:openurlfulltext>\n
         \             </prim:links>\n              <prim:search>\n                <prim:creatorcontrib>Steyaert,
@@ -259,7 +252,8 @@ http_interactions:
         as ‘linguascapes’: Negotiating the position of English through discursive
         practices</prim:title>\n                <prim:author>Steyaert, Chris ; Ostendorp,
         Anja ; Gaibrois, Claudine</prim:author>\n                <prim:creationdate>20110000</prim:creationdate>\n
-        \             </prim:sort>\n              <prim:facets>\n                <prim:language>eng</prim:language>\n
+        \             </prim:sort>\n              <prim:facets>\n                <prim:frbrgroupid>8038343634252234115</prim:frbrgroupid>\n
+        \               <prim:frbrtype>5</prim:frbrtype>\n                <prim:language>eng</prim:language>\n
         \               <prim:creationdate>2011</prim:creationdate>\n                <prim:topic>Negotiated
         Multilingualism</prim:topic>\n                <prim:topic>Discourse Analysis</prim:topic>\n
         \               <prim:topic>Linguascape</prim:topic>\n                <prim:topic>Englishization</prim:topic>\n
@@ -271,18 +265,17 @@ http_interactions:
         Anja</prim:creatorcontrib>\n                <prim:creatorcontrib>Gaibrois,
         Claudine</prim:creatorcontrib>\n                <prim:jtitle>Journal Of World
         Business</prim:jtitle>\n                <prim:toplevel>peer_reviewed</prim:toplevel>\n
-        \               <prim:frbrgroupid>8038343634252234115</prim:frbrgroupid>\n
-        \               <prim:frbrtype>5</prim:frbrtype>\n              </prim:facets>\n
-        \             <prim:frbr>\n                <prim:t>2</prim:t>\n                <prim:k1>2011</prim:k1>\n
-        \               <prim:k2>10909516</prim:k2>\n                <prim:k3>10.1016/j.jwb.2010.07.003</prim:k3>\n
-        \               <prim:k4>46</prim:k4>\n                <prim:k5>3</prim:k5>\n
-        \               <prim:k6>270</prim:k6>\n                <prim:k7>journal of
-        world business</prim:k7>\n                <prim:k8>multilingual organizations
-        as ‘linguascapes’ negotiating the position of english through discursive practices</prim:k8>\n
-        \               <prim:k9>multilingualorganizatices</prim:k9>\n                <prim:k12>multilingualorganizations</prim:k12>\n
-        \               <prim:k15>chrissteyaert</prim:k15>\n                <prim:k16>steyaertchris</prim:k16>\n
-        \             </prim:frbr>\n              <prim:delivery>\n                <prim:delcategory>Remote
-        Search Resource</prim:delcategory>\n                <prim:fulltext>fulltext</prim:fulltext>\n
+        \             </prim:facets>\n              <prim:frbr>\n                <prim:t>2</prim:t>\n
+        \               <prim:k1>2011</prim:k1>\n                <prim:k2>10909516</prim:k2>\n
+        \               <prim:k3>10.1016/j.jwb.2010.07.003</prim:k3>\n                <prim:k4>46</prim:k4>\n
+        \               <prim:k5>3</prim:k5>\n                <prim:k6>270</prim:k6>\n
+        \               <prim:k7>journal of world business</prim:k7>\n                <prim:k8>multilingual
+        organizations as ‘linguascapes’ negotiating the position of english through
+        discursive practices</prim:k8>\n                <prim:k9>multilingualorganizatices</prim:k9>\n
+        \               <prim:k12>multilingualorganizations</prim:k12>\n                <prim:k15>chrissteyaert</prim:k15>\n
+        \               <prim:k16>steyaertchris</prim:k16>\n              </prim:frbr>\n
+        \             <prim:delivery>\n                <prim:delcategory>Remote Search
+        Resource</prim:delcategory>\n                <prim:fulltext>fulltext</prim:fulltext>\n
         \             </prim:delivery>\n              <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
         \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>publisher</prim:pcg_type>\n
         \             </prim:ranking>\n              <prim:addata>\n                <prim:aulast>Steyaert</prim:aulast>\n
@@ -307,16 +300,163 @@ http_interactions:
         how the flow of languages that cross a specific organizational space is discursively
         mediated.</prim:abstract>\n                <prim:doi>10.1016/j.jwb.2010.07.003</prim:doi>\n
         \             </prim:addata>\n            </prim:record>\n          </prim:PrimoNMBib>\n
-        \         <sear:GETIT GetIt2=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-08-20T15%3A54%3A45IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert%2C%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft_id=info:oai/>\"
-        GetIt1=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-08-20T15%3A54%3A45IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert%2C%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft_id=info:oai/>\"
-        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-08-20T15%3A54%3A45IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&rft.jtitle=Journal%20of%20World%20Business&rft.btitle=&rft.aulast=Steyaert&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Steyaert%2C%20Chris&rft.aucorp=&rft.date=2011&rft.volume=46&rft.issue=3&rft.part=&rft.quarter=&rft.ssn=&rft.spage=270&rft.epage=278&rft.pages=270-278&rft.artnum=&rft.issn=1090-9516&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1016/j.jwb.2010.07.003&rft.eisbn=&rft_dat=<sciversesciencedirect_elsevier>S1090-9516(10)00042-8</sciversesciencedirect_elsevier>&rft_id=info:oai/>]]></sear:openurl>\n
+        \         <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&rft.jtitle=Journal%20of%20World%20Business&rft.btitle=&rft.aulast=Steyaert&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Steyaert,%20Chris&rft.aucorp=&rft.date=2011&rft.volume=46&rft.issue=3&rft.part=&rft.quarter=&rft.ssn=&rft.spage=270&rft.epage=278&rft.pages=270-278&rft.artnum=&rft.issn=1090-9516&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1016/j.jwb.2010.07.003&rft.object_id=&rft_dat=<sciversesciencedirect_elsevier>S1090-9516(10)00042-8</sciversesciencedirect_elsevier>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
         \           <sear:backlink>http://dx.doi.org/10.1016/j.jwb.2010.07.003</sear:backlink>\n
-        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-08-20T15%3A54%3A45IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&rft.jtitle=Journal%20of%20World%20Business&rft.btitle=&rft.aulast=Steyaert&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Steyaert%2C%20Chris&rft.aucorp=&rft.date=2011&rft.volume=46&rft.issue=3&rft.part=&rft.quarter=&rft.ssn=&rft.spage=270&rft.epage=278&rft.pages=270-278&rft.artnum=&rft.issn=1090-9516&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1016/j.jwb.2010.07.003&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft.eisbn=&rft_dat=<sciversesciencedirect_elsevier>S1090-9516(10)00042-8</sciversesciencedirect_elsevier>&rft_id=info:oai/>]]></sear:openurlfulltext>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&rft.jtitle=Journal%20of%20World%20Business&rft.btitle=&rft.aulast=Steyaert&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Steyaert,%20Chris&rft.aucorp=&rft.date=2011&rft.volume=46&rft.issue=3&rft.part=&rft.quarter=&rft.ssn=&rft.spage=270&rft.epage=278&rft.pages=270-278&rft.artnum=&rft.issn=1090-9516&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1016/j.jwb.2010.07.003&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<sciversesciencedirect_elsevier>S1090-9516(10)00042-8</sciversesciencedirect_elsevier>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&rft.jtitle=Journal%20of%20World%20Business&rft.btitle=&rft.aulast=Steyaert&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Steyaert,%20Chris&rft.aucorp=&rft.date=2011&rft.volume=46&rft.issue=3&rft.part=&rft.quarter=&rft.ssn=&rft.spage=270&rft.epage=278&rft.pages=270-278&rft.artnum=&rft.issn=1090-9516&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1016/j.jwb.2010.07.003&rft.object_id=&rft_dat=<sciversesciencedirect_elsevier>S1090-9516(10)00042-8</sciversesciencedirect_elsevier>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:backlink>http://dx.doi.org/10.1016/j.jwb.2010.07.003</sear:backlink>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&rft.jtitle=Journal%20of%20World%20Business&rft.btitle=&rft.aulast=Steyaert&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Steyaert,%20Chris&rft.aucorp=&rft.date=2011&rft.volume=46&rft.issue=3&rft.part=&rft.quarter=&rft.ssn=&rft.spage=270&rft.epage=278&rft.pages=270-278&rft.artnum=&rft.issn=1090-9516&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1016/j.jwb.2010.07.003&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<sciversesciencedirect_elsevier>S1090-9516(10)00042-8</sciversesciencedirect_elsevier>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
         \         </sear:LINKS>\n        </sear:DOC>\n        <sear:DOC LOCAL=\"false\"
         SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
-        NO=\"2\" RANK=\"0.046819586\" ID=\"212867501\">\n          <prim:PrimoNMBib
+        NO=\"2\" RANK=\"0.058583084\" ID=\"17238766\">\n          <prim:PrimoNMBib
         xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n
-        \           <prim:record>\n              <prim:control>\n                <prim:sourcerecordid>581Annals48</prim:sourcerecordid>\n
+        \           <prim:record>\n              <prim:control>\n                <prim:sourcerecordid>134458487</prim:sourcerecordid>\n
+        \               <prim:sourceid>gale_ofa</prim:sourceid>\n                <prim:recordid>TN_gale_ofa134458487</prim:recordid>\n
+        \               <prim:sourceformat>XML</prim:sourceformat>\n                <prim:sourcesystem>Other</prim:sourcesystem>\n
+        \             </prim:control>\n              <prim:display>\n                <prim:type>article</prim:type>\n
+        \               <prim:title><![CDATA[Transforming resistance, broadening our
+        boundaries: critical organizational communication meets <span class=\"searchword\">globalization</span>
+        <span class=\"searchword\">from</span> <span class=\"searchword\">below</span>.(Author
+        Abstract)]]></prim:title>\n                <prim:creator>Ganesh, Shiv ; Zoller,
+        Heather ; Cheney, George</prim:creator>\n                <prim:ispartof>Communication
+        Monographs, June, 2005, Vol.72(2), p.169(23)</prim:ispartof>\n                <prim:identifier>&lt;b>ISSN:
+        &lt;/b>0363-7751</prim:identifier>\n                <prim:subject>&lt;span
+        class=\"searchword\">Globalization&lt;/span> -- Social Aspects</prim:subject>\n
+        \               <prim:description>This essay addresses the need for organizational
+        communication scholarship to come to terms with the contested nature of &lt;span
+        class=\"searchword\">globalization&lt;/span> through analyses of collective
+        resistance. We argue that organizational communication has largely situated
+        the study of resistance at the level of the individual, and characterized
+        it as an element of micro-politics located within organizational boundaries.
+        Thus, resistance has been considered in localized, interpersonal terms, without
+        full appreciation of its political and ideological significance. This essay
+        builds a case for reconsidering resistance in order to study \"&lt;span class=\"searchword\">globalization&lt;/span>
+        &lt;span class=\"searchword\">from&lt;/span> &lt;span class=\"searchword\">below&lt;/span>\"
+        and highlights protest movements as exemplars of transformative resistance.
+        Finally, the essay advances a study of organizational communication with expanded
+        disciplinary engagement with respect to &lt;span class=\"searchword\">globalization&lt;/span>.
+        Keywords: Critical Studies; &lt;span class=\"searchword\">Globalization&lt;/span>;
+        Organizational Communication; Resistance; Social Movements</prim:description>\n
+        \               <prim:language>English</prim:language>\n                <prim:source>Cengage
+        Learning, Inc.</prim:source>\n                <prim:lds50>peer_reviewed</prim:lds50>\n
+        \               <prim:version>5</prim:version>\n                <prim:snippetfield>description</prim:snippetfield>\n
+        \               <prim:snippetfield>subject</prim:snippetfield>\n                <prim:snippetfield>description</prim:snippetfield>\n
+        \               <prim:snippetfield>description</prim:snippetfield>\n                <prim:snippetfield>title</prim:snippetfield>\n
+        \               <prim:snippet>disciplinary engagement with respect to &lt;span
+        class=\"searchword\">globalization&lt;/span>. Keywords: Critical Studies;
+        &lt;span class=\"searchword\">Globalization&lt;/span>; Organizational Communication;
+        Resistance; Social Movements... &lt;span class=\"searchword\">Globalization&lt;/span>--Social
+        aspects... This essay addresses the need for organizational communication
+        scholarship to come to terms with the contested nature of &lt;span class=\"searchword\">globalization&lt;/span>
+        through analyses of collective resistance. We argue...  in order to study
+        \"&lt;span class=\"searchword\">globalization&lt;/span> &lt;span class=\"searchword\">from&lt;/span>
+        &lt;span class=\"searchword\">below&lt;/span>\" and highlights protest movements
+        as exemplars of transformative resistance. Finally, the essay advances a study
+        of organizational communication with expanded... Transforming resistance,
+        broadening our boundaries: critical organizational communication meets &lt;span
+        class=\"searchword\">globalization&lt;/span> &lt;span class=\"searchword\">from&lt;/span>
+        &lt;span class=\"searchword\">below&lt;/span>.(Author Abstract)</prim:snippet>\n
+        \             </prim:display>\n              <prim:links>\n                <prim:openurl>$$Topenurl_article</prim:openurl>\n
+        \               <prim:openurlfulltext>$$Topenurlfull_article</prim:openurlfulltext>\n
+        \             </prim:links>\n              <prim:search>\n                <prim:scope>gale_onefileg</prim:scope>\n
+        \               <prim:scope>gale_onefilea</prim:scope>\n                <prim:creatorcontrib>Ganesh,
+        Shiv</prim:creatorcontrib>\n                <prim:creatorcontrib>Ganesh</prim:creatorcontrib>\n
+        \               <prim:creatorcontrib>Zoller, Heather</prim:creatorcontrib>\n
+        \               <prim:creatorcontrib>Cheney, George</prim:creatorcontrib>\n
+        \               <prim:title><![CDATA[Transforming resistance, broadening our
+        boundaries: critical organizational communication meets <span class=\"searchword\">globalization</span>
+        <span class=\"searchword\">from</span> <span class=\"searchword\">below</span>.(Author
+        Abstract)]]></prim:title>\n                <prim:description>This essay addresses
+        the need for organizational communication scholarship to come to terms with
+        the contested nature of globalization through analyses of collective resistance.
+        We argue that organizational communication has largely situated the study
+        of resistance at the level of the individual, and characterized it as an element
+        of micro-politics located within organizational boundaries. Thus, resistance
+        has been considered in localized, interpersonal terms, without full appreciation
+        of its political and ideological significance. This essay builds a case for
+        reconsidering resistance in order to study \"globalization from below\" and
+        highlights protest movements as exemplars of transformative resistance. Finally,
+        the essay advances a study of organizational communication with expanded disciplinary
+        engagement with respect to globalization. Keywords: Critical Studies; Globalization;
+        Organizational Communication; Resistance; Social Movements</prim:description>\n
+        \               <prim:subject>Globalization--Social aspects</prim:subject>\n
+        \               <prim:general>English</prim:general>\n                <prim:general>Speech
+        Communication Association</prim:general>\n                <prim:general>Cengage
+        Learning, Inc.</prim:general>\n                <prim:sourceid>gale_ofa</prim:sourceid>\n
+        \               <prim:recordid>gale_ofa134458487</prim:recordid>\n                <prim:issn>0363-7751</prim:issn>\n
+        \               <prim:issn>03637751</prim:issn>\n                <prim:rsrctype>article</prim:rsrctype>\n
+        \               <prim:creationdate>2005</prim:creationdate>\n                <prim:recordtype>article</prim:recordtype>\n
+        \               <prim:addtitle>Communication Monographs</prim:addtitle>\n
+        \               <prim:searchscope>OneFile</prim:searchscope>\n                <prim:scope>OneFile</prim:scope>\n
+        \             </prim:search>\n              <prim:sort>\n                <prim:title>Transforming
+        resistance, broadening our boundaries: critical organizational communication
+        meets globalization from below.(Author Abstract)</prim:title>\n                <prim:author>Ganesh,
+        Shiv ; Zoller, Heather ; Cheney, George</prim:author>\n                <prim:creationdate>20050601</prim:creationdate>\n
+        \             </prim:sort>\n              <prim:facets>\n                <prim:frbrgroupid>4308494945219945461</prim:frbrgroupid>\n
+        \               <prim:frbrtype>5</prim:frbrtype>\n                <prim:language>eng</prim:language>\n
+        \               <prim:creationdate>2005</prim:creationdate>\n                <prim:topic>Globalization–Social
+        Aspects</prim:topic>\n                <prim:collection>OneFile (GALE)</prim:collection>\n
+        \               <prim:prefilter>articles</prim:prefilter>\n                <prim:rsrctype>articles</prim:rsrctype>\n
+        \               <prim:creatorcontrib>Ganesh, Shiv</prim:creatorcontrib>\n
+        \               <prim:creatorcontrib>Zoller, Heather</prim:creatorcontrib>\n
+        \               <prim:creatorcontrib>Cheney, George</prim:creatorcontrib>\n
+        \               <prim:jtitle>Communication Monographs</prim:jtitle>\n                <prim:toplevel>peer_reviewed</prim:toplevel>\n
+        \             </prim:facets>\n              <prim:frbr>\n                <prim:t>2</prim:t>\n
+        \               <prim:k1>2005</prim:k1>\n                <prim:k2>03637751</prim:k2>\n
+        \               <prim:k4>72</prim:k4>\n                <prim:k5>2</prim:k5>\n
+        \               <prim:k6>169</prim:k6>\n                <prim:k7>communication
+        monographs</prim:k7>\n                <prim:k8>transforming resistance broadening
+        our boundaries critical organizational communication meets globalization from
+        below</prim:k8>\n                <prim:k9>transformingresistanbelow</prim:k9>\n
+        \               <prim:k12>transformingresistancebro</prim:k12>\n                <prim:k15>shivganesh</prim:k15>\n
+        \               <prim:k16>ganeshshiv</prim:k16>\n              </prim:frbr>\n
+        \             <prim:delivery>\n                <prim:delcategory>Remote Search
+        Resource</prim:delcategory>\n                <prim:fulltext>fulltext</prim:fulltext>\n
+        \             </prim:delivery>\n              <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
+        \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>aggregator</prim:pcg_type>\n
+        \             </prim:ranking>\n              <prim:addata>\n                <prim:au>Ganesh,
+        Shiv</prim:au>\n                <prim:au>Zoller, Heather</prim:au>\n                <prim:au>Cheney,
+        George</prim:au>\n                <prim:atitle>Transforming resistance, broadening
+        our boundaries: critical organizational communication meets globalization
+        from below.(Author Abstract)</prim:atitle>\n                <prim:jtitle>Communication
+        Monographs</prim:jtitle>\n                <prim:date>20050601</prim:date>\n
+        \               <prim:risdate>20050601</prim:risdate>\n                <prim:volume>72</prim:volume>\n
+        \               <prim:issue>2</prim:issue>\n                <prim:spage>169</prim:spage>\n
+        \               <prim:issn>0363-7751</prim:issn>\n                <prim:genre>article</prim:genre>\n
+        \               <prim:ristype>JOUR</prim:ristype>\n                <prim:abstract>This
+        essay addresses the need for organizational communication scholarship to come
+        to terms with the contested nature of globalization through analyses of collective
+        resistance. We argue that organizational communication has largely situated
+        the study of resistance at the level of the individual, and characterized
+        it as an element of micro-politics located within organizational boundaries.
+        Thus, resistance has been considered in localized, interpersonal terms, without
+        full appreciation of its political and ideological significance. This essay
+        builds a case for reconsidering resistance in order to study \"globalization
+        from below\" and highlights protest movements as exemplars of transformative
+        resistance. Finally, the essay advances a study of organizational communication
+        with expanded disciplinary engagement with respect to globalization. Keywords:
+        Critical Studies; Globalization; Organizational Communication; Resistance;
+        Social Movements</prim:abstract>\n                <prim:pub>Speech Communication
+        Association</prim:pub>\n                <prim:lad01>gale_ofa</prim:lad01>\n
+        \             </prim:addata>\n            </prim:record>\n          </prim:PrimoNMBib>\n
+        \         <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Transforming%20resistance,%20broadening%20our%20boundaries:%20critical%20organizational%20communication%20meets%20globalization%20from%20below.(Author%20Abstract)&rft.jtitle=Communication%20Monographs&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Ganesh,%20Shiv&rft.aucorp=&rft.date=20050601&rft.volume=72&rft.issue=2&rft.part=&rft.quarter=&rft.ssn=&rft.spage=169&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0363-7751&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>134458487</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Transforming%20resistance,%20broadening%20our%20boundaries:%20critical%20organizational%20communication%20meets%20globalization%20from%20below.(Author%20Abstract)&rft.jtitle=Communication%20Monographs&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Ganesh,%20Shiv&rft.aucorp=&rft.date=20050601&rft.volume=72&rft.issue=2&rft.part=&rft.quarter=&rft.ssn=&rft.spage=169&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0363-7751&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>134458487</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Transforming%20resistance,%20broadening%20our%20boundaries:%20critical%20organizational%20communication%20meets%20globalization%20from%20below.(Author%20Abstract)&rft.jtitle=Communication%20Monographs&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Ganesh,%20Shiv&rft.aucorp=&rft.date=20050601&rft.volume=72&rft.issue=2&rft.part=&rft.quarter=&rft.ssn=&rft.spage=169&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0363-7751&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>134458487</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Transforming%20resistance,%20broadening%20our%20boundaries:%20critical%20organizational%20communication%20meets%20globalization%20from%20below.(Author%20Abstract)&rft.jtitle=Communication%20Monographs&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Ganesh,%20Shiv&rft.aucorp=&rft.date=20050601&rft.volume=72&rft.issue=2&rft.part=&rft.quarter=&rft.ssn=&rft.spage=169&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0363-7751&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>134458487</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n        </sear:DOC>\n        <sear:DOC LOCAL=\"false\"
+        SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
+        NO=\"3\" RANK=\"0.046980307\" ID=\"162777620\">\n          <prim:PrimoNMBib
+        xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
+        xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n            <prim:record>\n
+        \             <prim:control>\n                <prim:sourcerecordid>581Annals48</prim:sourcerecordid>\n
         \               <prim:sourceid>lexisnexis_lawreviews</prim:sourceid>\n                <prim:recordid>TN_lexisnexis_lawreviews581Annals48</prim:recordid>\n
         \               <prim:sourcesystem>Other</prim:sourcesystem>\n              </prim:control>\n
         \             <prim:display>\n                <prim:type>article</prim:type>\n
@@ -404,7 +544,8 @@ http_interactions:
         \             <prim:sort>\n                <prim:title>Globalization from
         Below: Toward a Collectively Rational and Democratic Global Commonwealth</prim:title>\n
         \               <prim:author>Christopher Chase-Dunn</prim:author>\n                <prim:creationdate>20020501</prim:creationdate>\n
-        \             </prim:sort>\n              <prim:facets>\n                <prim:creationdate>2002</prim:creationdate>\n
+        \             </prim:sort>\n              <prim:facets>\n                <prim:frbrgroupid>-471525565</prim:frbrgroupid>\n
+        \               <prim:frbrtype>6</prim:frbrtype>\n                <prim:creationdate>2002</prim:creationdate>\n
         \               <prim:topic>Sociopolitical</prim:topic>\n                <prim:topic>Opportunities</prim:topic>\n
         \               <prim:topic>Institutional</prim:topic>\n                <prim:topic>Transnational</prim:topic>\n
         \               <prim:topic>International</prim:topic>\n                <prim:topic>Semiperiphery</prim:topic>\n
@@ -415,7 +556,6 @@ http_interactions:
         \               <prim:rsrctype>articles</prim:rsrctype>\n                <prim:creatorcontrib>By
         Christopher Chase-Dunn</prim:creatorcontrib>\n                <prim:jtitle>Annals
         Of The American Academy Of Political And Social Science</prim:jtitle>\n                <prim:toplevel>peer_reviewed</prim:toplevel>\n
-        \               <prim:frbrgroupid>558362689</prim:frbrgroupid>\n                <prim:frbrtype>6</prim:frbrtype>\n
         \             </prim:facets>\n              <prim:frbr>\n                <prim:t>2</prim:t>\n
         \               <prim:k1>2002</prim:k1>\n                <prim:k2>00027162</prim:k2>\n
         \               <prim:k2>15523349</prim:k2>\n                <prim:k4>581</prim:k4>\n
@@ -461,106 +601,314 @@ http_interactions:
         The modern world-system originated out of an expanding multicore Afro-Eurasian
         world-system in which the Europeans rose ...</prim:abstract>\n              </prim:addata>\n
         \           </prim:record>\n          </prim:PrimoNMBib>\n          <sear:GETIT
-        GetIt2=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-08-20T15%3A54%3A45IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert%2C%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft_id=info:oai/>\"
-        GetIt1=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-08-20T15%3A54%3A45IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert%2C%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft_id=info:oai/>\"
-        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-08-20T15%3A54%3A45IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-lexisnexis_lawreviews&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20Toward%20a%20Collectively%20Rational%20and%20Democratic%20Global%20Commonwealth&rft.jtitle=Annals%20of%20the%20American%20Academy%20of%20Political%20and%20Social%20Science&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=By%20Christopher%20Chase-Dunn&rft.aucorp=&rft.date=20020501&rft.volume=581&rft.issue=&rft.part=&rft.quarter=&rft.ssn=&rft.spage=48&rft.epage=172&rft.pages=&rft.artnum=&rft.issn=0002-7162&rft.eissn=1552-3349&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.eisbn=&rft_dat=<lexisnexis_lawreviews>581Annals48</lexisnexis_lawreviews>&rft_id=info:oai/>]]></sear:openurl>\n
+        GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-lexisnexis_lawreviews&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20Toward%20a%20Collectively%20Rational%20and%20Democratic%20Global%20Commonwealth&rft.jtitle=Annals%20of%20the%20American%20Academy%20of%20Political%20and%20Social%20Science&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=By%20Christopher%20Chase-Dunn&rft.aucorp=&rft.date=20020501&rft.volume=581&rft.issue=&rft.part=&rft.quarter=&rft.ssn=&rft.spage=48&rft.epage=172&rft.pages=&rft.artnum=&rft.issn=0002-7162&rft.eissn=1552-3349&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<lexisnexis_lawreviews>581Annals48</lexisnexis_lawreviews>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
         \           <sear:linktorsrc>http://www.lexisnexis.com/hottopics/lnacademic/?verb=sr&amp;csi=7327&amp;sr=cite(581+Annals+48)</sear:linktorsrc>\n
-        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-08-20T15%3A54%3A45IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-lexisnexis_lawreviews&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20Toward%20a%20Collectively%20Rational%20and%20Democratic%20Global%20Commonwealth&rft.jtitle=Annals%20of%20the%20American%20Academy%20of%20Political%20and%20Social%20Science&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=By%20Christopher%20Chase-Dunn&rft.aucorp=&rft.date=20020501&rft.volume=581&rft.issue=&rft.part=&rft.quarter=&rft.ssn=&rft.spage=48&rft.epage=172&rft.pages=&rft.artnum=&rft.issn=0002-7162&rft.eissn=1552-3349&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft.eisbn=&rft_dat=<lexisnexis_lawreviews>581Annals48</lexisnexis_lawreviews>&rft_id=info:oai/>]]></sear:openurlfulltext>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-lexisnexis_lawreviews&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20Toward%20a%20Collectively%20Rational%20and%20Democratic%20Global%20Commonwealth&rft.jtitle=Annals%20of%20the%20American%20Academy%20of%20Political%20and%20Social%20Science&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=By%20Christopher%20Chase-Dunn&rft.aucorp=&rft.date=20020501&rft.volume=581&rft.issue=&rft.part=&rft.quarter=&rft.ssn=&rft.spage=48&rft.epage=172&rft.pages=&rft.artnum=&rft.issn=0002-7162&rft.eissn=1552-3349&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<lexisnexis_lawreviews>581Annals48</lexisnexis_lawreviews>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-lexisnexis_lawreviews&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20Toward%20a%20Collectively%20Rational%20and%20Democratic%20Global%20Commonwealth&rft.jtitle=Annals%20of%20the%20American%20Academy%20of%20Political%20and%20Social%20Science&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=By%20Christopher%20Chase-Dunn&rft.aucorp=&rft.date=20020501&rft.volume=581&rft.issue=&rft.part=&rft.quarter=&rft.ssn=&rft.spage=48&rft.epage=172&rft.pages=&rft.artnum=&rft.issn=0002-7162&rft.eissn=1552-3349&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<lexisnexis_lawreviews>581Annals48</lexisnexis_lawreviews>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:linktorsrc>http://www.lexisnexis.com/hottopics/lnacademic/?verb=sr&amp;csi=7327&amp;sr=cite(581+Annals+48)</sear:linktorsrc>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-lexisnexis_lawreviews&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20Toward%20a%20Collectively%20Rational%20and%20Democratic%20Global%20Commonwealth&rft.jtitle=Annals%20of%20the%20American%20Academy%20of%20Political%20and%20Social%20Science&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=By%20Christopher%20Chase-Dunn&rft.aucorp=&rft.date=20020501&rft.volume=581&rft.issue=&rft.part=&rft.quarter=&rft.ssn=&rft.spage=48&rft.epage=172&rft.pages=&rft.artnum=&rft.issn=0002-7162&rft.eissn=1552-3349&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<lexisnexis_lawreviews>581Annals48</lexisnexis_lawreviews>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
         \         </sear:LINKS>\n        </sear:DOC>\n        <sear:DOC LOCAL=\"false\"
         SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
-        NO=\"3\" RANK=\"0.035256714\" ID=\"173367864\">\n          <prim:PrimoNMBib
+        NO=\"4\" RANK=\"0.03659006\" ID=\"370135854\">\n          <prim:PrimoNMBib
         xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
         xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n            <prim:record>\n
-        \             <prim:control>\n                <prim:sourcerecordid>67161994</prim:sourcerecordid>\n
-        \               <prim:sourceid>gale_ofa</prim:sourceid>\n                <prim:recordid>TN_gale_ofa67161994</prim:recordid>\n
-        \               <prim:sourceformat>XML</prim:sourceformat>\n                <prim:sourcesystem>Other</prim:sourcesystem>\n
-        \             </prim:control>\n              <prim:display>\n                <prim:type>article</prim:type>\n
-        \               <prim:title><![CDATA[<span class=\"searchword\">Globalization</span>
-        <span class=\"searchword\">From</span> <span class=\"searchword\">Below</span>
-        : INTERNATIONAL SOLIDARITY IS THE KEY TO CONSOLIDATING THE LEGACY OF SEATTLE.(grassroots
-        social movements)]]></prim:title>\n                <prim:creator>Brecher,
-        Jeremy ; Costello, Tim ; Smith, Brendan</prim:creator>\n                <prim:ispartof>The
-        Nation, Dec 4, 2000, Vol.271(18), p.19</prim:ispartof>\n                <prim:identifier>&lt;b>ISSN:
-        &lt;/b>0027-8378</prim:identifier>\n                <prim:subject>International
-        Economic Relations -- Social Aspects ; Activists -- Behavior ; Environmentalism
-        -- Political Aspects ; Social Movements -- Political Aspects ; Feminism --
-        Political Aspects ; Labor Movement -- Political Aspects</prim:subject>\n                <prim:source>Cengage
-        Learning, Inc.</prim:source>\n                <prim:version>1</prim:version>\n
-        \               <prim:snippetfield>title</prim:snippetfield>\n                <prim:snippet><![CDATA[<span
-        class=\"searchword\">Globalization</span> <span class=\"searchword\">From</span>
-        <span class=\"searchword\">Below</span> : INTERNATIONAL SOLIDARITY IS THE
-        KEY TO CONSOLIDATING THE LEGACY OF SEATTLE.(grassroots social movements)]]></prim:snippet>\n
-        \             </prim:display>\n              <prim:links>\n                <prim:openurl>$$Topenurl_article</prim:openurl>\n
+        \             <prim:control>\n                <prim:sourcerecordid>EJ921737</prim:sourcerecordid>\n
+        \               <prim:sourceid>eric</prim:sourceid>\n                <prim:recordid>TN_ericEJ921737</prim:recordid>\n
+        \               <prim:sourcesystem>Other</prim:sourcesystem>\n              </prim:control>\n
+        \             <prim:display>\n                <prim:type>article</prim:type>\n
+        \               <prim:title><![CDATA[Porto Alegre as a Counter-Hegemonic \"Global
+        City\": Building <span class=\"searchword\">Globalization</span> <span class=\"searchword\">from</span>
+        <span class=\"searchword\">below</span> in Governance and Education]]></prim:title>\n
+        \               <prim:creator>Gandin, Luis Armando</prim:creator>\n                <prim:ispartof>Discourse:
+        Studies in the Cultural Politics of Education, 2011, Vol.32(2), p.235-252</prim:ispartof>\n
+        \               <prim:identifier>&lt;b>ISSN: &lt;/b>0159-6306 ; &lt;b>DOI:
+        &lt;/b></prim:identifier>\n                <prim:subject>Foreign Countries;
+        Political Attitudes; Economic Development; Educational Policy; Global Approach;
+        Municipalities; Reputation; Democracy; Governance; Authoritarianism; Critical
+        Theory</prim:subject>\n                <prim:description>This paper analyzes
+        the case of Porto Alegre, Brazil as a counter-hegemonic global city. Porto
+        Alegre is a city with no particular relevance to neoliberal &lt;span class=\"searchword\">globalization&lt;/span>
+        that, nevertheless, was launched to a global scale by transformations in local
+        governance. New mechanisms of deliberative democracy captured the attention
+        of social actors constructing a movement of &lt;span class=\"searchword\">globalization&lt;/span>
+        &lt;span class=\"searchword\">from&lt;/span> &lt;span class=\"searchword\">below&lt;/span>,
+        making Porto Alegre the de facto capital of the World Social Forum. In this
+        paper I focus on the educational policies created in the city, which expanded
+        the social imaginary in education and are a key component of Porto Alegre's
+        \"&lt;span class=\"searchword\">globalization&lt;/span>\". (Contains 8 notes.)</prim:description>\n
+        \               <prim:language>eng</prim:language>\n                <prim:source>ERIC
+        (U.S. Dept. of Education)</prim:source>\n                <prim:lds50>peer_reviewed</prim:lds50>\n
+        \               <prim:version>4</prim:version>\n                <prim:snippetfield>general</prim:snippetfield>\n
+        \               <prim:snippetfield>description</prim:snippetfield>\n                <prim:snippetfield>description</prim:snippetfield>\n
+        \               <prim:snippetfield>description</prim:snippetfield>\n                <prim:snippetfield>title</prim:snippetfield>\n
+        \               <prim:snippet>Routledge. Available &lt;span class=\"searchword\">from&lt;/span>:
+        Taylor &amp; Francis, Ltd. 325 Chestnut Street Suite 800, Philadelphia, PA
+        19106. Tel: 800-354-1420; Fax: 215-625-2940; Web site: http://www.tandf.co.uk/journals...
+        This paper analyzes the case of Porto Alegre, Brazil as a counter-hegemonic
+        global city. Porto Alegre is a city with no particular relevance to neoliberal
+        &lt;span class=\"searchword\">globalization&lt;/span> that, nevertheless...
+        \ component of Porto Alegre's \"&lt;span class=\"searchword\">globalization&lt;/span>\".
+        (Contains 8 notes.)... , was launched to a global scale by transformations
+        in local governance. New mechanisms of deliberative democracy captured the
+        attention of social actors constructing a movement of &lt;span class=\"searchword\">globalization&lt;/span>
+        &lt;span class=\"searchword\">from&lt;/span> &lt;span class=\"searchword\">below&lt;/span>...
+        Porto Alegre as a Counter-Hegemonic \"Global City\": Building &lt;span class=\"searchword\">Globalization&lt;/span>
+        &lt;span class=\"searchword\">from&lt;/span> &lt;span class=\"searchword\">below&lt;/span>
+        in Governance and Education</prim:snippet>\n              </prim:display>\n
+        \             <prim:links>\n                <prim:openurl>$$Topenurl_article</prim:openurl>\n
+        \               <prim:backlink>$$Uhttp://www.informaworld.com/openurl?genre=article&amp;id=doi:10.1080/01596306.2011.562669$$EView_source_record</prim:backlink>\n
         \               <prim:openurlfulltext>$$Topenurlfull_article</prim:openurlfulltext>\n
-        \             </prim:links>\n              <prim:search>\n                <prim:creatorcontrib>Brecher,
-        Jeremy</prim:creatorcontrib>\n                <prim:creatorcontrib>Costello,
-        Tim</prim:creatorcontrib>\n                <prim:creatorcontrib>Smith, Brendan</prim:creatorcontrib>\n
-        \               <prim:title><![CDATA[<span class=\"searchword\">Globalization</span>
-        <span class=\"searchword\">From</span> <span class=\"searchword\">Below</span>
-        : INTERNATIONAL SOLIDARITY IS THE KEY TO CONSOLIDATING THE LEGACY OF SEATTLE.(grassroots
-        social movements)]]></prim:title>\n                <prim:subject>International
-        economic relations--Social aspects</prim:subject>\n                <prim:subject>Activists--Behavior</prim:subject>\n
-        \               <prim:subject>Environmentalism--Political aspects</prim:subject>\n
-        \               <prim:subject>Social movements--Political aspects</prim:subject>\n
-        \               <prim:subject>Feminism--Political aspects</prim:subject>\n
-        \               <prim:subject>Labor movement--Political aspects</prim:subject>\n
-        \               <prim:subject>00WOR</prim:subject>\n                <prim:subject>World</prim:subject>\n
-        \               <prim:subject>Demonstrations and protests</prim:subject>\n
-        \               <prim:subject>International Monetary Fund</prim:subject>\n
-        \               <prim:subject>World Trade Organization</prim:subject>\n                <prim:general>The
-        Nation Company L.P.</prim:general>\n                <prim:general>Cengage
-        Learning, Inc.</prim:general>\n                <prim:sourceid>gale_ofa</prim:sourceid>\n
-        \               <prim:recordid>gale_ofa67161994</prim:recordid>\n                <prim:issn>0027-8378</prim:issn>\n
-        \               <prim:issn>00278378</prim:issn>\n                <prim:rsrctype>article</prim:rsrctype>\n
-        \               <prim:creationdate>2000</prim:creationdate>\n                <prim:recordtype>article</prim:recordtype>\n
-        \               <prim:addtitle>The Nation</prim:addtitle>\n                <prim:searchscope>OneFile</prim:searchscope>\n
-        \               <prim:scope>OneFile</prim:scope>\n              </prim:search>\n
-        \             <prim:sort>\n                <prim:title>Globalization From
-        Below : INTERNATIONAL SOLIDARITY IS THE KEY TO CONSOLIDATING THE LEGACY OF
-        SEATTLE.(grassroots social movements)</prim:title>\n                <prim:author>Brecher,
-        Jeremy ; Costello, Tim ; Smith, Brendan</prim:author>\n                <prim:creationdate>20001204</prim:creationdate>\n
-        \             </prim:sort>\n              <prim:facets>\n                <prim:creationdate>2000</prim:creationdate>\n
-        \               <prim:topic>International Economic Relations–Social Aspects</prim:topic>\n
-        \               <prim:topic>Activists–Behavior</prim:topic>\n                <prim:topic>Environmentalism–Political
-        Aspects</prim:topic>\n                <prim:topic>Social Movements–Political
-        Aspects</prim:topic>\n                <prim:topic>Feminism–Political Aspects</prim:topic>\n
-        \               <prim:topic>Labor Movement–Political Aspects</prim:topic>\n
-        \               <prim:collection>OneFile (GALE)</prim:collection>\n                <prim:prefilter>articles</prim:prefilter>\n
-        \               <prim:rsrctype>articles</prim:rsrctype>\n                <prim:creatorcontrib>Brecher,
-        Jeremy</prim:creatorcontrib>\n                <prim:creatorcontrib>Costello,
-        Tim</prim:creatorcontrib>\n                <prim:creatorcontrib>Smith, Brendan</prim:creatorcontrib>\n
-        \               <prim:jtitle>The Nation</prim:jtitle>\n                <prim:frbrgroupid>6516380186211662130</prim:frbrgroupid>\n
-        \               <prim:frbrtype>5</prim:frbrtype>\n              </prim:facets>\n
-        \             <prim:frbr>\n                <prim:t>2</prim:t>\n                <prim:k1>2000</prim:k1>\n
-        \               <prim:k2>00278378</prim:k2>\n                <prim:k4>271</prim:k4>\n
-        \               <prim:k5>18</prim:k5>\n                <prim:k6>19</prim:k6>\n
-        \               <prim:k7>nation</prim:k7>\n                <prim:k8>globalization
-        from below international solidarity is the key to consolidating the legacy
-        of seattle</prim:k8>\n                <prim:k9>globalizationfrombelattle</prim:k9>\n
-        \               <prim:k12>globalizationfrombelowint</prim:k12>\n                <prim:k15>jeremybrecher</prim:k15>\n
-        \               <prim:k16>brecherjeremy</prim:k16>\n              </prim:frbr>\n
+        \               <prim:addlink>$$Uhttp://fe.p.prod.primo.saas.exlibrisgroup.com:1701/primo_library/libweb/aboutEric.html$$DView
+        the U.S. Department of Education (ERIC) Copyright Statement</prim:addlink>\n
+        \             </prim:links>\n              <prim:search>\n                <prim:creatorcontrib>Gandin,
+        Luis Armando</prim:creatorcontrib>\n                <prim:title><![CDATA[Porto
+        Alegre as a Counter-Hegemonic \"Global City\": Building <span class=\"searchword\">Globalization</span>
+        <span class=\"searchword\">from</span> <span class=\"searchword\">below</span>
+        in Governance and Education]]></prim:title>\n                <prim:description>This
+        paper analyzes the case of Porto Alegre, Brazil as a counter-hegemonic global
+        city. Porto Alegre is a city with no particular relevance to neoliberal globalization
+        that, nevertheless, was launched to a global scale by transformations in local
+        governance. New mechanisms of deliberative democracy captured the attention
+        of social actors constructing a movement of globalization from below, making
+        Porto Alegre the de facto capital of the World Social Forum. In this paper
+        I focus on the educational policies created in the city, which expanded the
+        social imaginary in education and are a key component of Porto Alegre's \"globalization\".
+        (Contains 8 notes.)</prim:description>\n                <prim:subject>Foreign
+        Countries</prim:subject>\n                <prim:subject>Political Attitudes</prim:subject>\n
+        \               <prim:subject>Economic Development</prim:subject>\n                <prim:subject>Educational
+        Policy</prim:subject>\n                <prim:subject>Global Approach</prim:subject>\n
+        \               <prim:subject>Municipalities</prim:subject>\n                <prim:subject>Reputation</prim:subject>\n
+        \               <prim:subject>Democracy</prim:subject>\n                <prim:subject>Governance</prim:subject>\n
+        \               <prim:subject>Authoritarianism</prim:subject>\n                <prim:subject>Critical
+        Theory</prim:subject>\n                <prim:general>English</prim:general>\n
+        \               <prim:general>ERIC (U.S. Dept. of Education)</prim:general>\n
+        \               <prim:general>Routledge. Available from: Taylor &amp; Francis,
+        Ltd. 325 Chestnut Street Suite 800, Philadelphia, PA 19106. Tel: 800-354-1420;
+        Fax: 215-625-2940; Web site: http://www.tandf.co.uk/journals</prim:general>\n
+        \               <prim:sourceid>eric</prim:sourceid>\n                <prim:recordid>ericEJ921737</prim:recordid>\n
+        \               <prim:issn>ISSN01596306</prim:issn>\n                <prim:issn>ISSN-0159-6306</prim:issn>\n
+        \               <prim:rsrctype>article</prim:rsrctype>\n                <prim:creationdate>2011</prim:creationdate>\n
+        \               <prim:addtitle>Discourse: Studies in the Cultural Politics
+        of Education</prim:addtitle>\n                <prim:searchscope>eric</prim:searchscope>\n
+        \               <prim:scope>eric</prim:scope>\n                <prim:lsr45>This~paper~analyzes~the~case~of~porto~alegre,~brazil~as~a~counter-hegemonic~global~city.~porto~alegre~is~a~city~with~no~particular~relevance~to~neoliberal~globalization~that,~nevertheless,~was~launched~to~a~global~scale~by~transformations~in~local~governance.~new~mechanisms~of~deliberative~democracy~captured~the~attention~of~social~actors~constructing~a~movement~of~globalization~from~below,~making~porto~alegre~the~de~facto~capital~of~the~world~social~forum.~in~this~paper~i~focus~on~the~educational~policies~created~in~the~city,~which~expanded~the~social~imaginary~in~education~and~are~a~key~component~of~porto~alegre's~\"globalization\".~(contains~8~notes.)</prim:lsr45>\n
+        \               <prim:lsr46>Porto~alegre~as~a~counter-hegemonic~\"global~city\":~building~globalization~from~below~in~governance~and~education</prim:lsr46>\n
+        \               <prim:lsr48>Vol.32(2), p.235-252</prim:lsr48>\n              </prim:search>\n
+        \             <prim:sort>\n                <prim:author>Gandin, Luis Armando</prim:author>\n
+        \               <prim:title>Porto Alegre as a Counter-Hegemonic \"Global City\":
+        Building Globalization from below in Governance and Education</prim:title>\n
+        \               <prim:creationdate>20110000</prim:creationdate>\n              </prim:sort>\n
+        \             <prim:facets>\n                <prim:frbrgroupid>5232036365367745387</prim:frbrgroupid>\n
+        \               <prim:frbrtype>5</prim:frbrtype>\n                <prim:language>eng</prim:language>\n
+        \               <prim:creationdate>2011</prim:creationdate>\n                <prim:topic>Foreign
+        Countries</prim:topic>\n                <prim:topic>Political Attitudes</prim:topic>\n
+        \               <prim:topic>Economic Development</prim:topic>\n                <prim:topic>Educational
+        Policy</prim:topic>\n                <prim:topic>Global Approach</prim:topic>\n
+        \               <prim:topic>Municipalities</prim:topic>\n                <prim:topic>Reputation</prim:topic>\n
+        \               <prim:topic>Democracy</prim:topic>\n                <prim:topic>Governance</prim:topic>\n
+        \               <prim:topic>Authoritarianism</prim:topic>\n                <prim:topic>Critical
+        Theory</prim:topic>\n                <prim:collection>ERIC (U.S. Dept. of
+        Education)</prim:collection>\n                <prim:prefilter>articles</prim:prefilter>\n
+        \               <prim:rsrctype>articles</prim:rsrctype>\n                <prim:creatorcontrib>Gandin,
+        Luis Armando</prim:creatorcontrib>\n                <prim:jtitle>Discourse:
+        Studies in the Cultural Politics of Education</prim:jtitle>\n                <prim:toplevel>peer_reviewed</prim:toplevel>\n
+        \             </prim:facets>\n              <prim:frbr>\n                <prim:t>2</prim:t>\n
+        \               <prim:k1>2011</prim:k1>\n                <prim:k2>01596306</prim:k2>\n
+        \               <prim:k4>32</prim:k4>\n                <prim:k5>2</prim:k5>\n
+        \               <prim:k6>235</prim:k6>\n                <prim:k7>discourse
+        studies in the cultural politics of education</prim:k7>\n                <prim:k8>porto
+        alegre as counter hegemonic quot global city quot building globalization from
+        below in governance education</prim:k8>\n                <prim:k9>portoalegreasacounteation</prim:k9>\n
+        \               <prim:k12>portoalegreasacounterhege</prim:k12>\n                <prim:k15>luisarmandogandin</prim:k15>\n
+        \               <prim:k16>gandinluisarmando</prim:k16>\n              </prim:frbr>\n
         \             <prim:delivery>\n                <prim:delcategory>Remote Search
         Resource</prim:delcategory>\n                <prim:fulltext>fulltext</prim:fulltext>\n
         \             </prim:delivery>\n              <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
-        \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>aggregator</prim:pcg_type>\n
-        \             </prim:ranking>\n              <prim:addata>\n                <prim:au>Brecher,
-        Jeremy</prim:au>\n                <prim:au>Costello, Tim</prim:au>\n                <prim:au>Smith,
-        Brendan</prim:au>\n                <prim:atitle>Globalization From Below :
-        INTERNATIONAL SOLIDARITY IS THE KEY TO CONSOLIDATING THE LEGACY OF SEATTLE.(grassroots
-        social movements)</prim:atitle>\n                <prim:jtitle>The Nation</prim:jtitle>\n
-        \               <prim:date>20001204</prim:date>\n                <prim:risdate>20001204</prim:risdate>\n
-        \               <prim:volume>271</prim:volume>\n                <prim:issue>18</prim:issue>\n
-        \               <prim:spage>19</prim:spage>\n                <prim:issn>0027-8378</prim:issn>\n
-        \               <prim:genre>article</prim:genre>\n                <prim:ristype>JOUR</prim:ristype>\n
-        \               <prim:pub>The Nation Company L.P.</prim:pub>\n                <prim:lad01>gale_ofa</prim:lad01>\n
-        \             </prim:addata>\n            </prim:record>\n          </prim:PrimoNMBib>\n
-        \         <sear:GETIT GetIt2=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-08-20T15%3A54%3A45IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert%2C%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft_id=info:oai/>\"
-        GetIt1=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-08-20T15%3A54%3A45IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert%2C%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft_id=info:oai/>\"
-        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-08-20T15%3A54%3A45IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20From%20Below%20:%20INTERNATIONAL%20SOLIDARITY%20IS%20THE%20KEY%20TO%20CONSOLIDATING%20THE%20LEGACY%20OF%20SEATTLE.(grassroots%20social%20movements)&rft.jtitle=The%20Nation&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Brecher%2C%20Jeremy&rft.aucorp=&rft.date=20001204&rft.volume=271&rft.issue=18&rft.part=&rft.quarter=&rft.ssn=&rft.spage=19&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0027-8378&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.eisbn=&rft_dat=<gale_ofa>67161994</gale_ofa>&rft_id=info:oai/>]]></sear:openurl>\n
-        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-08-20T15%3A54%3A45IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20From%20Below%20:%20INTERNATIONAL%20SOLIDARITY%20IS%20THE%20KEY%20TO%20CONSOLIDATING%20THE%20LEGACY%20OF%20SEATTLE.(grassroots%20social%20movements)&rft.jtitle=The%20Nation&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Brecher%2C%20Jeremy&rft.aucorp=&rft.date=20001204&rft.volume=271&rft.issue=18&rft.part=&rft.quarter=&rft.ssn=&rft.spage=19&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0027-8378&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft.eisbn=&rft_dat=<gale_ofa>67161994</gale_ofa>&rft_id=info:oai/>]]></sear:openurlfulltext>\n
+        \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>publisher</prim:pcg_type>\n
+        \             </prim:ranking>\n              <prim:addata>\n                <prim:au>Gandin,
+        Luis Armando</prim:au>\n                <prim:atitle>Porto Alegre as a Counter-Hegemonic
+        \"Global City\": Building Globalization from below in Governance and Education</prim:atitle>\n
+        \               <prim:jtitle>Discourse: Studies in the Cultural Politics of
+        Education</prim:jtitle>\n                <prim:date>2011</prim:date>\n                <prim:risdate>2011</prim:risdate>\n
+        \               <prim:volume>32</prim:volume>\n                <prim:issue>2</prim:issue>\n
+        \               <prim:spage>235</prim:spage>\n                <prim:epage>252</prim:epage>\n
+        \               <prim:issn>0159-6306</prim:issn>\n                <prim:genre>article</prim:genre>\n
+        \               <prim:ristype>JOUR</prim:ristype>\n                <prim:abstract>This
+        paper analyzes the case of Porto Alegre, Brazil as a counter-hegemonic global
+        city. Porto Alegre is a city with no particular relevance to neoliberal globalization
+        that, nevertheless, was launched to a global scale by transformations in local
+        governance. New mechanisms of deliberative democracy captured the attention
+        of social actors constructing a movement of globalization from below, making
+        Porto Alegre the de facto capital of the World Social Forum. In this paper
+        I focus on the educational policies created in the city, which expanded the
+        social imaginary in education and are a key component of Porto Alegre's \"globalization\".
+        (Contains 8 notes.)</prim:abstract>\n                <prim:pub>Routledge.
+        Available from: Taylor &amp; Francis, Ltd. 325 Chestnut Street Suite 800,
+        Philadelphia, PA 19106. Tel: 800-354-1420; Fax: 215-625-2940; Web site: http://www.tandf.co.uk/journals</prim:pub>\n
+        \               <prim:format>article</prim:format>\n              </prim:addata>\n
+        \           </prim:record>\n          </prim:PrimoNMBib>\n          <sear:GETIT
+        GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-eric&rft_val_fmt=info:ofi/fmt:kev:mtx:article&rft.genre=article&rft.atitle=Porto%20Alegre%20as%20a%20Counter-Hegemonic%20\"Global%20City\":%20Building%20Globalization%20from%20below%20in%20Governance%20and%20Education&rft.jtitle=Discourse:%20Studies%20in%20the%20Cultural%20Politics%20of%20Education&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Gandin,%20Luis%20Armando&rft.aucorp=&rft.date=2011&rft.volume=32&rft.issue=2&rft.part=&rft.quarter=&rft.ssn=&rft.spage=235&rft.epage=252&rft.pages=&rft.artnum=&rft.issn=0159-6306&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<eric>EJ921737</eric>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:backlink>http://www.informaworld.com/openurl?genre=article&amp;id=doi:10.1080/01596306.2011.562669</sear:backlink>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-eric&rft_val_fmt=info:ofi/fmt:kev:mtx:article&rft.genre=article&rft.atitle=Porto%20Alegre%20as%20a%20Counter-Hegemonic%20\"Global%20City\":%20Building%20Globalization%20from%20below%20in%20Governance%20and%20Education&rft.jtitle=Discourse:%20Studies%20in%20the%20Cultural%20Politics%20of%20Education&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Gandin,%20Luis%20Armando&rft.aucorp=&rft.date=2011&rft.volume=32&rft.issue=2&rft.part=&rft.quarter=&rft.ssn=&rft.spage=235&rft.epage=252&rft.pages=&rft.artnum=&rft.issn=0159-6306&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<eric>EJ921737</eric>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \           <sear:addlink>http://fe.p.prod.primo.saas.exlibrisgroup.com:1701/primo_library/libweb/aboutEric.html</sear:addlink>\n
+        \         </sear:LINKS>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-eric&rft_val_fmt=info:ofi/fmt:kev:mtx:article&rft.genre=article&rft.atitle=Porto%20Alegre%20as%20a%20Counter-Hegemonic%20\"Global%20City\":%20Building%20Globalization%20from%20below%20in%20Governance%20and%20Education&rft.jtitle=Discourse:%20Studies%20in%20the%20Cultural%20Politics%20of%20Education&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Gandin,%20Luis%20Armando&rft.aucorp=&rft.date=2011&rft.volume=32&rft.issue=2&rft.part=&rft.quarter=&rft.ssn=&rft.spage=235&rft.epage=252&rft.pages=&rft.artnum=&rft.issn=0159-6306&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<eric>EJ921737</eric>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:backlink>http://www.informaworld.com/openurl?genre=article&amp;id=doi:10.1080/01596306.2011.562669</sear:backlink>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-eric&rft_val_fmt=info:ofi/fmt:kev:mtx:article&rft.genre=article&rft.atitle=Porto%20Alegre%20as%20a%20Counter-Hegemonic%20\"Global%20City\":%20Building%20Globalization%20from%20below%20in%20Governance%20and%20Education&rft.jtitle=Discourse:%20Studies%20in%20the%20Cultural%20Politics%20of%20Education&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Gandin,%20Luis%20Armando&rft.aucorp=&rft.date=2011&rft.volume=32&rft.issue=2&rft.part=&rft.quarter=&rft.ssn=&rft.spage=235&rft.epage=252&rft.pages=&rft.artnum=&rft.issn=0159-6306&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<eric>EJ921737</eric>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \           <sear:addlink>http://fe.p.prod.primo.saas.exlibrisgroup.com:1701/primo_library/libweb/aboutEric.html</sear:addlink>\n
         \         </sear:LINKS>\n        </sear:DOC>\n        <sear:DOC LOCAL=\"false\"
         SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
-        NO=\"4\" RANK=\"0.03263488\" ID=\"300944790\">\n          <prim:PrimoNMBib
+        NO=\"5\" RANK=\"0.03515992\" ID=\"361448016\">\n          <prim:PrimoNMBib
+        xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
+        xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n            <prim:record>\n
+        \             <prim:control>\n                <prim:sourcerecordid>10.1177_0896920511399938</prim:sourcerecordid>\n
+        \               <prim:sourceid>sagej</prim:sourceid>\n                <prim:recordid>TN_sagej10.1177_0896920511399938</prim:recordid>\n
+        \               <prim:sourceformat>XML</prim:sourceformat>\n                <prim:sourcesystem>Other</prim:sourcesystem>\n
+        \             </prim:control>\n              <prim:display>\n                <prim:type>article</prim:type>\n
+        \               <prim:title><![CDATA[<span class=\"searchword\">Globalization</span>
+        <span class=\"searchword\">from</span> <span class=\"searchword\">Below</span>:
+        Labor Activists Challenging the AFL-CIO Foreign Policy Program]]></prim:title>\n
+        \               <prim:creator>Scipes, Kim</prim:creator>\n                <prim:identifier><![CDATA[<b>ISSN:</b>
+        0896-9205 ; <b>E-ISSN:</b> 1569-1632 ; <b>DOI:</b> 10.1177/0896920511399938]]></prim:identifier>\n
+        \               <prim:subject>Afl-cio ; Labor ; Labor Imperialism ; Labor
+        Movements ; Social Movements ; Sociology ; Uslaw ; Wwsc</prim:subject>\n                <prim:description>Building
+        on Alberto Melucci’s argument that to understand a social movement, we must
+        look at the period before emergence as a social movement, this article examines
+        labor activists’ efforts to reform the foreign policy program of the AFL-CIO:
+        has sufficient groundwork been laid that a serious possibility of an alternative
+        &lt;span class=\"searchword\">globalization&lt;/span> movement can emerge
+        &lt;span class=\"searchword\">from&lt;/span> within US Labor? This article
+        discusses general efforts to challenge the AFL-CIO’s foreign policy program.
+        It examines the work of US Labor Against the War (USLAW) since its founding
+        in 2003, the California State AFL-CIO’s formal repudiation of the AFL-CIO
+        foreign policy program in 2004, and then efforts at the 2005 National AFL-CIO
+        Convention to keep California’s ‘Build Unity and Trust With Workers Worldwide’
+        resolution &lt;span class=\"searchword\">from&lt;/span> being fairly discussed
+        at the Convention. Based on evidence presented, it then evaluates whether
+        there is an alternative &lt;span class=\"searchword\">globalization&lt;/span>
+        movement emerging within US Labor or not.</prim:description>\n                <prim:source>SAGE
+        Publications</prim:source>\n                <prim:lds40>2012</prim:lds40>\n
+        \               <prim:lds41>Critical Sociology, 2012, Vol.38(2), pp.303-323</prim:lds41>\n
+        \               <prim:lds44>20123</prim:lds44>\n                <prim:lds45>20123</prim:lds45>\n
+        \               <prim:ispartof>Critical Sociology, 2012, Vol.38(2), pp.303-323</prim:ispartof>\n
+        \               <prim:lds50>peer_reviewed</prim:lds50>\n                <prim:version>2</prim:version>\n
+        \               <prim:snippetfield>description</prim:snippetfield>\n                <prim:snippetfield>description</prim:snippetfield>\n
+        \               <prim:snippetfield>description</prim:snippetfield>\n                <prim:snippetfield>title</prim:snippetfield>\n
+        \               <prim:snippet>fairly discussed at the Convention. Based on
+        evidence presented, it then evaluates whether there is an alternative &lt;span
+        class=\"searchword\">globalization&lt;/span> movement emerging within US Labor
+        or not....  repudiation of the AFL-CIO foreign policy program in 2004, and
+        then efforts at the 2005 National AFL-CIO Convention to keep California’s
+        ‘Build Unity and Trust With Workers Worldwide’ resolution &lt;span class=\"searchword\">from&lt;/span>
+        being...  the foreign policy program of the AFL-CIO: has sufficient groundwork
+        been laid that a serious possibility of an alternative &lt;span class=\"searchword\">globalization&lt;/span>
+        movement can emerge &lt;span class=\"searchword\">from&lt;/span> within US
+        Labor? This article... &lt;span class=\"searchword\">Globalization&lt;/span>
+        &lt;span class=\"searchword\">from&lt;/span> &lt;span class=\"searchword\">Below&lt;/span>:
+        Labor Activists Challenging the AFL-CIO Foreign Policy Program</prim:snippet>\n
+        \             </prim:display>\n              <prim:links>\n                <prim:openurl>$$Topenurl_article</prim:openurl>\n
+        \               <prim:openurlfulltext>$$Topenurlfull_article</prim:openurlfulltext>\n
+        \             </prim:links>\n              <prim:search>\n                <prim:creatorcontrib>Scipes,
+        Kim</prim:creatorcontrib>\n                <prim:title><![CDATA[<span class=\"searchword\">Globalization</span>
+        <span class=\"searchword\">from</span> <span class=\"searchword\">Below</span>:
+        Labor Activists Challenging the AFL-CIO Foreign Policy Program]]></prim:title>\n
+        \               <prim:description>Building on Alberto Melucci’s argument that
+        to understand a social movement, we must look at the period before emergence
+        as a social movement, this article examines labor activists’ efforts to reform
+        the foreign policy program of the AFL-CIO: has sufficient groundwork been
+        laid that a serious possibility of an alternative globalization movement can
+        emerge from within US Labor? This article discusses general efforts to challenge
+        the AFL-CIO’s foreign policy program. It examines the work of US Labor Against
+        the War (USLAW) since its founding in 2003, the California State AFL-CIO’s
+        formal repudiation of the AFL-CIO foreign policy program in 2004, and then
+        efforts at the 2005 National AFL-CIO Convention to keep California’s ‘Build
+        Unity and Trust With Workers Worldwide’ resolution from being fairly discussed
+        at the Convention. Based on evidence presented, it then evaluates whether
+        there is an alternative globalization movement emerging within US Labor or
+        not.</prim:description>\n                <prim:subject>Afl-cio</prim:subject>\n
+        \               <prim:subject>Labor</prim:subject>\n                <prim:subject>Labor
+        Imperialism</prim:subject>\n                <prim:subject>Labor Movements</prim:subject>\n
+        \               <prim:subject>Social Movements</prim:subject>\n                <prim:subject>Sociology</prim:subject>\n
+        \               <prim:subject>Uslaw</prim:subject>\n                <prim:subject>Wwsc</prim:subject>\n
+        \               <prim:general>10.1177/0896920511399938</prim:general>\n                <prim:general>SAGE
+        Journals</prim:general>\n                <prim:sourceid>sagej</prim:sourceid>\n
+        \               <prim:recordid>sagej10.1177_0896920511399938</prim:recordid>\n
+        \               <prim:issn>08969205</prim:issn>\n                <prim:issn>0896-9205</prim:issn>\n
+        \               <prim:issn>15691632</prim:issn>\n                <prim:issn>1569-1632</prim:issn>\n
+        \               <prim:rsrctype>article</prim:rsrctype>\n                <prim:creationdate>2012</prim:creationdate>\n
+        \               <prim:recordtype>article</prim:recordtype>\n                <prim:addtitle>Critical
+        Sociology</prim:addtitle>\n                <prim:searchscope>sagej</prim:searchscope>\n
+        \               <prim:searchscope>SAGE Journals</prim:searchscope>\n                <prim:searchscope>sage</prim:searchscope>\n
+        \               <prim:scope>sagej</prim:scope>\n                <prim:scope>SAGE
+        Journals</prim:scope>\n                <prim:scope>sage</prim:scope>\n              </prim:search>\n
+        \             <prim:sort>\n                <prim:title>Globalization from
+        Below: Labor Activists Challenging the AFL-CIO Foreign Policy Program</prim:title>\n
+        \               <prim:author>Scipes, Kim</prim:author>\n              </prim:sort>\n
+        \             <prim:facets>\n                <prim:frbrgroupid>8294983320581585922</prim:frbrgroupid>\n
+        \               <prim:frbrtype>5</prim:frbrtype>\n                <prim:topic>Afl-cio</prim:topic>\n
+        \               <prim:topic>Labor</prim:topic>\n                <prim:topic>Labor
+        Imperialism</prim:topic>\n                <prim:topic>Labor Movements</prim:topic>\n
+        \               <prim:topic>Social Movements</prim:topic>\n                <prim:topic>Sociology</prim:topic>\n
+        \               <prim:topic>Uslaw</prim:topic>\n                <prim:topic>Wwsc</prim:topic>\n
+        \               <prim:collection>SAGE Journals</prim:collection>\n                <prim:prefilter>articles</prim:prefilter>\n
+        \               <prim:rsrctype>articles</prim:rsrctype>\n                <prim:creatorcontrib>Scipes,
+        Kim</prim:creatorcontrib>\n                <prim:jtitle>Critical Sociology</prim:jtitle>\n
+        \               <prim:creationdate>2012</prim:creationdate>\n                <prim:toplevel>peer_reviewed</prim:toplevel>\n
+        \             </prim:facets>\n              <prim:frbr>\n                <prim:t>2</prim:t>\n
+        \               <prim:k1>2012</prim:k1>\n                <prim:k2>08969205</prim:k2>\n
+        \               <prim:k2>15691632</prim:k2>\n                <prim:k3>10.1177/0896920511399938</prim:k3>\n
+        \               <prim:k4>38</prim:k4>\n                <prim:k5>2</prim:k5>\n
+        \               <prim:k6>303</prim:k6>\n                <prim:k7>critical
+        sociology</prim:k7>\n                <prim:k8>globalization from below labor
+        activists challenging the afl cio foreign policy program</prim:k8>\n                <prim:k9>globalizationfrombelogram</prim:k9>\n
+        \               <prim:k12>globalizationfrombelowlab</prim:k12>\n                <prim:k15>kimscipes</prim:k15>\n
+        \               <prim:k16>scipeskim</prim:k16>\n              </prim:frbr>\n
+        \             <prim:delivery>\n                <prim:delcategory>Remote Search
+        Resource</prim:delcategory>\n                <prim:fulltext>fulltext</prim:fulltext>\n
+        \             </prim:delivery>\n              <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
+        \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>publisher</prim:pcg_type>\n
+        \             </prim:ranking>\n              <prim:addata>\n                <prim:aulast>Scipes</prim:aulast>\n
+        \               <prim:aufirst>Kim</prim:aufirst>\n                <prim:au>Scipes,
+        Kim</prim:au>\n                <prim:atitle>Globalization from Below: Labor
+        Activists Challenging the AFL-CIO Foreign Policy Program</prim:atitle>\n                <prim:jtitle>Critical
+        Sociology</prim:jtitle>\n                <prim:date>20123</prim:date>\n                <prim:risdate>20123</prim:risdate>\n
+        \               <prim:volume>38</prim:volume>\n                <prim:issue>2</prim:issue>\n
+        \               <prim:spage>303</prim:spage>\n                <prim:epage>323</prim:epage>\n
+        \               <prim:issn>0896-9205</prim:issn>\n                <prim:eissn>1569-1632</prim:eissn>\n
+        \               <prim:format>article</prim:format>\n                <prim:genre>article</prim:genre>\n
+        \               <prim:ristype>JOUR</prim:ristype>\n                <prim:abstract>Building
+        on Alberto Melucci’s argument that to understand a social movement, we must
+        look at the period before emergence as a social movement, this article examines
+        labor activists’ efforts to reform the foreign policy program of the AFL-CIO:
+        has sufficient groundwork been laid that a serious possibility of an alternative
+        globalization movement can emerge from within US Labor? This article discusses
+        general efforts to challenge the AFL-CIO’s foreign policy program. It examines
+        the work of US Labor Against the War (USLAW) since its founding in 2003, the
+        California State AFL-CIO’s formal repudiation of the AFL-CIO foreign policy
+        program in 2004, and then efforts at the 2005 National AFL-CIO Convention
+        to keep California’s ‘Build Unity and Trust With Workers Worldwide’ resolution
+        from being fairly discussed at the Convention. Based on evidence presented,
+        it then evaluates whether there is an alternative globalization movement emerging
+        within US Labor or not.</prim:abstract>\n                <prim:pub>SAGE Publications</prim:pub>\n
+        \               <prim:doi>10.1177/0896920511399938</prim:doi>\n              </prim:addata>\n
+        \           </prim:record>\n          </prim:PrimoNMBib>\n          <sear:GETIT
+        GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sagej&rft_val_fmt=info:ofi/fmt:kev:mtx:article&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20Labor%20Activists%20Challenging%20the%20AFL-CIO%20Foreign%20Policy%20Program&rft.jtitle=Critical%20Sociology&rft.btitle=&rft.aulast=Scipes&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Scipes,%20Kim&rft.aucorp=&rft.date=20123&rft.volume=38&rft.issue=2&rft.part=&rft.quarter=&rft.ssn=&rft.spage=303&rft.epage=323&rft.pages=&rft.artnum=&rft.issn=0896-9205&rft.eissn=1569-1632&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1177/0896920511399938&rft.object_id=&rft_dat=<sagej>10.1177_0896920511399938</sagej>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sagej&rft_val_fmt=info:ofi/fmt:kev:mtx:article&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20Labor%20Activists%20Challenging%20the%20AFL-CIO%20Foreign%20Policy%20Program&rft.jtitle=Critical%20Sociology&rft.btitle=&rft.aulast=Scipes&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Scipes,%20Kim&rft.aucorp=&rft.date=20123&rft.volume=38&rft.issue=2&rft.part=&rft.quarter=&rft.ssn=&rft.spage=303&rft.epage=323&rft.pages=&rft.artnum=&rft.issn=0896-9205&rft.eissn=1569-1632&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1177/0896920511399938&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<sagej>10.1177_0896920511399938</sagej>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sagej&rft_val_fmt=info:ofi/fmt:kev:mtx:article&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20Labor%20Activists%20Challenging%20the%20AFL-CIO%20Foreign%20Policy%20Program&rft.jtitle=Critical%20Sociology&rft.btitle=&rft.aulast=Scipes&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Scipes,%20Kim&rft.aucorp=&rft.date=20123&rft.volume=38&rft.issue=2&rft.part=&rft.quarter=&rft.ssn=&rft.spage=303&rft.epage=323&rft.pages=&rft.artnum=&rft.issn=0896-9205&rft.eissn=1569-1632&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1177/0896920511399938&rft.object_id=&rft_dat=<sagej>10.1177_0896920511399938</sagej>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sagej&rft_val_fmt=info:ofi/fmt:kev:mtx:article&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20Labor%20Activists%20Challenging%20the%20AFL-CIO%20Foreign%20Policy%20Program&rft.jtitle=Critical%20Sociology&rft.btitle=&rft.aulast=Scipes&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Scipes,%20Kim&rft.aucorp=&rft.date=20123&rft.volume=38&rft.issue=2&rft.part=&rft.quarter=&rft.ssn=&rft.spage=303&rft.epage=323&rft.pages=&rft.artnum=&rft.issn=0896-9205&rft.eissn=1569-1632&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1177/0896920511399938&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<sagej>10.1177_0896920511399938</sagej>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n        </sear:DOC>\n        <sear:DOC LOCAL=\"false\"
+        SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
+        NO=\"6\" RANK=\"0.032735337\" ID=\"85633995\">\n          <prim:PrimoNMBib
         xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
         xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n            <prim:record>\n
         \             <prim:control>\n                <prim:sourcerecordid>10.1086/518061</prim:sourcerecordid>\n
@@ -595,13 +943,13 @@ http_interactions:
         \             </prim:search>\n              <prim:sort>\n                <prim:title>Globalization
         from Below: Transnational Activists and Protest Networks (Book-Review)</prim:title>\n
         \               <prim:author>Myers, DanielJ</prim:author>\n                <prim:creationdate>20070300</prim:creationdate>\n
-        \             </prim:sort>\n              <prim:facets>\n                <prim:creationdate>2007</prim:creationdate>\n
+        \             </prim:sort>\n              <prim:facets>\n                <prim:frbrgroupid>-6747201201460193143</prim:frbrgroupid>\n
+        \               <prim:frbrtype>6</prim:frbrtype>\n                <prim:creationdate>2007</prim:creationdate>\n
         \               <prim:collection>University of Chicago Press Journals</prim:collection>\n
         \               <prim:prefilter>articles</prim:prefilter>\n                <prim:rsrctype>articles</prim:rsrctype>\n
         \               <prim:creatorcontrib>Myers, DanielJ.</prim:creatorcontrib>\n
         \               <prim:jtitle>American Journal of Sociology</prim:jtitle>\n
-        \               <prim:toplevel>peer_reviewed</prim:toplevel>\n                <prim:frbrgroupid>266517745</prim:frbrgroupid>\n
-        \               <prim:frbrtype>6</prim:frbrtype>\n              </prim:facets>\n
+        \               <prim:toplevel>peer_reviewed</prim:toplevel>\n              </prim:facets>\n
         \             <prim:frbr>\n                <prim:t>2</prim:t>\n                <prim:k1>2007</prim:k1>\n
         \               <prim:k2>00029602</prim:k2>\n                <prim:k2>15375390</prim:k2>\n
         \               <prim:k3>10.1086/518061</prim:k3>\n                <prim:k4>112</prim:k4>\n
@@ -609,7 +957,7 @@ http_interactions:
         \               <prim:k7>american journal of sociology</prim:k7>\n                <prim:k15>danieljmyers</prim:k15>\n
         \               <prim:k16>myersdanielj</prim:k16>\n              </prim:frbr>\n
         \             <prim:delivery>\n                <prim:delcategory>Remote Search
-        Resource</prim:delcategory>\n                <prim:fulltext>no_fulltext</prim:fulltext>\n
+        Resource</prim:delcategory>\n                <prim:fulltext>fulltext</prim:fulltext>\n
         \             </prim:delivery>\n              <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
         \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>publisher</prim:pcg_type>\n
         \             </prim:ranking>\n              <prim:addata>\n                <prim:aulast>Myers</prim:aulast>\n
@@ -622,166 +970,289 @@ http_interactions:
         \               <prim:genre>article</prim:genre>\n                <prim:ristype>JOUR</prim:ristype>\n
         \               <prim:pub>The University of Chicago Press</prim:pub>\n                <prim:doi>10.1086/518061</prim:doi>\n
         \             </prim:addata>\n            </prim:record>\n          </prim:PrimoNMBib>\n
-        \         <sear:GETIT GetIt2=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-08-20T15%3A54%3A45IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert%2C%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft_id=info:oai/>\"
-        GetIt1=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-08-20T15%3A54%3A45IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert%2C%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft_id=info:oai/>\"
-        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-08-20T15%3A54%3A45IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-ucp&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=&rft.jtitle=American%20Journal%20of%20Sociology&rft.btitle=&rft.aulast=Myers&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Myers%2C%20DanielJ.&rft.aucorp=&rft.date=200703&rft.volume=112&rft.issue=5&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1572&rft.epage=1573&rft.pages=&rft.artnum=&rft.issn=0002-9602&rft.eissn=1537-5390&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1086/518061&rft.eisbn=&rft_dat=<ucp>10.1086/518061</ucp>&rft_id=info:oai/>]]></sear:openurl>\n
-        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-08-20T15%3A54%3A45IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-ucp&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=&rft.jtitle=American%20Journal%20of%20Sociology&rft.btitle=&rft.aulast=Myers&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Myers%2C%20DanielJ.&rft.aucorp=&rft.date=200703&rft.volume=112&rft.issue=5&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1572&rft.epage=1573&rft.pages=&rft.artnum=&rft.issn=0002-9602&rft.eissn=1537-5390&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1086/518061&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft.eisbn=&rft_dat=<ucp>10.1086/518061</ucp>&rft_id=info:oai/>]]></sear:openurlfulltext>\n
+        \         <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-ucp&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=&rft.jtitle=American%20Journal%20of%20Sociology&rft.btitle=&rft.aulast=Myers&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Myers,%20DanielJ.&rft.aucorp=&rft.date=200703&rft.volume=112&rft.issue=5&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1572&rft.epage=1573&rft.pages=&rft.artnum=&rft.issn=0002-9602&rft.eissn=1537-5390&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1086/518061&rft.object_id=&rft_dat=<ucp>10.1086/518061</ucp>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-ucp&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=&rft.jtitle=American%20Journal%20of%20Sociology&rft.btitle=&rft.aulast=Myers&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Myers,%20DanielJ.&rft.aucorp=&rft.date=200703&rft.volume=112&rft.issue=5&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1572&rft.epage=1573&rft.pages=&rft.artnum=&rft.issn=0002-9602&rft.eissn=1537-5390&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1086/518061&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<ucp>10.1086/518061</ucp>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-ucp&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=&rft.jtitle=American%20Journal%20of%20Sociology&rft.btitle=&rft.aulast=Myers&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Myers,%20DanielJ.&rft.aucorp=&rft.date=200703&rft.volume=112&rft.issue=5&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1572&rft.epage=1573&rft.pages=&rft.artnum=&rft.issn=0002-9602&rft.eissn=1537-5390&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1086/518061&rft.object_id=&rft_dat=<ucp>10.1086/518061</ucp>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-ucp&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=&rft.jtitle=American%20Journal%20of%20Sociology&rft.btitle=&rft.aulast=Myers&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Myers,%20DanielJ.&rft.aucorp=&rft.date=200703&rft.volume=112&rft.issue=5&rft.part=&rft.quarter=&rft.ssn=&rft.spage=1572&rft.epage=1573&rft.pages=&rft.artnum=&rft.issn=0002-9602&rft.eissn=1537-5390&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1086/518061&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<ucp>10.1086/518061</ucp>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
         \         </sear:LINKS>\n        </sear:DOC>\n        <sear:DOC LOCAL=\"false\"
         SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
-        NO=\"5\" RANK=\"0.027729224\" ID=\"219223515\">\n          <prim:PrimoNMBib
+        NO=\"7\" RANK=\"0.028285734\" ID=\"361010496\">\n          <prim:PrimoNMBib
         xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
         xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n            <prim:record>\n
-        \             <prim:control>\n                <prim:sourcerecordid>10.1177/009430610603600252</prim:sourcerecordid>\n
-        \               <prim:sourceid>crossref</prim:sourceid>\n                <prim:recordid>TN_crossref10.1177/009430610603600252</prim:recordid>\n
+        \             <prim:control>\n                <prim:sourcerecordid>67161994</prim:sourcerecordid>\n
+        \               <prim:sourceid>gale_ofa</prim:sourceid>\n                <prim:recordid>TN_gale_ofa67161994</prim:recordid>\n
         \               <prim:sourceformat>XML</prim:sourceformat>\n                <prim:sourcesystem>Other</prim:sourcesystem>\n
         \             </prim:control>\n              <prim:display>\n                <prim:type>article</prim:type>\n
-        \               <prim:title><![CDATA[Product Review: <span class=\"searchword\">Globalization</span>
-        <span class=\"searchword\">from</span> <span class=\"searchword\">Below</span>:
-        Transnational Activists and Protest Networks]]></prim:title>\n                <prim:creator>Smith,
-        J.</prim:creator>\n                <prim:ispartof>Contemporary Sociology:
-        A Journal of Reviews, 2007, Vol.36(2), pp.191-192</prim:ispartof>\n                <prim:identifier>&lt;b>ISSN:&lt;/b>
-        0094-3061 ; &lt;b>DOI:&lt;/b> http://dx.doi.org/10.1177/009430610603600252</prim:identifier>\n
-        \               <prim:language>eng</prim:language>\n                <prim:source>Sage
-        Publications (via CrossRef)</prim:source>\n                <prim:lds50>peer_reviewed</prim:lds50>\n
-        \               <prim:snippetfield>title</prim:snippetfield>\n                <prim:snippet><![CDATA[Product
-        Review: <span class=\"searchword\">Globalization</span> <span class=\"searchword\">from</span>
-        <span class=\"searchword\">Below</span>: Transnational Activists and Protest
-        Networks]]></prim:snippet>\n              </prim:display>\n              <prim:links>\n
+        \               <prim:title><![CDATA[<span class=\"searchword\">Globalization</span>
+        <span class=\"searchword\">From</span> <span class=\"searchword\">Below</span>
+        : INTERNATIONAL SOLIDARITY IS THE KEY TO CONSOLIDATING THE LEGACY OF SEATTLE.(grassroots
+        social movements)]]></prim:title>\n                <prim:creator>Brecher,
+        Jeremy ; Costello, Tim ; Smith, Brendan</prim:creator>\n                <prim:ispartof>The
+        Nation, Dec 4, 2000, Vol.271(18), p.19</prim:ispartof>\n                <prim:identifier>&lt;b>ISSN:
+        &lt;/b>0027-8378</prim:identifier>\n                <prim:subject>International
+        Economic Relations -- Social Aspects ; Activists -- Behavior ; Environmentalism
+        -- Political Aspects ; Social Movements -- Political Aspects ; Feminism --
+        Political Aspects ; Labor Movement -- Political Aspects</prim:subject>\n                <prim:source>Cengage
+        Learning, Inc.</prim:source>\n                <prim:snippetfield>title</prim:snippetfield>\n
+        \               <prim:snippet><![CDATA[<span class=\"searchword\">Globalization</span>
+        <span class=\"searchword\">From</span> <span class=\"searchword\">Below</span>
+        : INTERNATIONAL SOLIDARITY IS THE KEY TO CONSOLIDATING THE LEGACY OF SEATTLE.(grassroots
+        social movements)]]></prim:snippet>\n              </prim:display>\n              <prim:links>\n
         \               <prim:openurl>$$Topenurl_article</prim:openurl>\n                <prim:openurlfulltext>$$Topenurlfull_article</prim:openurlfulltext>\n
-        \               <prim:addlink>$$Uhttp://fe.p.prod.primo.saas.exlibrisgroup.com:1701/primo_library/libweb/aboutCrossref.html$$DView
-        CrossRef copyright notice</prim:addlink>\n              </prim:links>\n              <prim:search>\n
-        \               <prim:creatorcontrib>Smith, J.</prim:creatorcontrib>\n                <prim:title><![CDATA[Product
-        Review: <span class=\"searchword\">Globalization</span> <span class=\"searchword\">from</span>
-        <span class=\"searchword\">Below</span>: Transnational Activists and Protest
-        Networks]]></prim:title>\n                <prim:general>English</prim:general>\n
-        \               <prim:general>10.1177/009430610603600252</prim:general>\n
-        \               <prim:sourceid>crossref</prim:sourceid>\n                <prim:recordid>crossref10.1177/009430610603600252</prim:recordid>\n
-        \               <prim:issn>0094-3061</prim:issn>\n                <prim:issn>00943061</prim:issn>\n
-        \               <prim:rsrctype>article</prim:rsrctype>\n                <prim:creationdate>2007</prim:creationdate>\n
-        \               <prim:addtitle>Contemporary Sociology: A Journal of Reviews</prim:addtitle>\n
-        \               <prim:searchscope>crossref_sp</prim:searchscope>\n                <prim:searchscope>CrossRef</prim:searchscope>\n
-        \               <prim:searchscope>Crossref</prim:searchscope>\n                <prim:searchscope>crossref</prim:searchscope>\n
-        \               <prim:scope>crossref_sp</prim:scope>\n                <prim:scope>CrossRef</prim:scope>\n
-        \               <prim:scope>Crossref</prim:scope>\n                <prim:scope>crossref</prim:scope>\n
-        \             </prim:search>\n              <prim:sort>\n                <prim:title>Product
-        Review: Globalization from Below: Transnational Activists and Protest Networks</prim:title>\n
-        \               <prim:author>Smith, J.</prim:author>\n                <prim:creationdate>20070301</prim:creationdate>\n
-        \             </prim:sort>\n              <prim:facets>\n                <prim:language>eng</prim:language>\n
-        \               <prim:creationdate>2007</prim:creationdate>\n                <prim:collection>Sage
-        Publications (CrossRef)</prim:collection>\n                <prim:prefilter>articles</prim:prefilter>\n
-        \               <prim:rsrctype>articles</prim:rsrctype>\n                <prim:creatorcontrib>Smith,
-        J.</prim:creatorcontrib>\n                <prim:jtitle>Contemporary Sociology:
-        A Journal Of Reviews</prim:jtitle>\n                <prim:toplevel>peer_reviewed</prim:toplevel>\n
-        \               <prim:frbrgroupid>330710846</prim:frbrgroupid>\n                <prim:frbrtype>6</prim:frbrtype>\n
-        \             </prim:facets>\n              <prim:frbr>\n                <prim:t>2</prim:t>\n
-        \               <prim:k1>2007</prim:k1>\n                <prim:k2>00943061</prim:k2>\n
-        \               <prim:k3>10.1177/009430610603600252</prim:k3>\n                <prim:k4>36</prim:k4>\n
-        \               <prim:k5>2</prim:k5>\n                <prim:k6>191</prim:k6>\n
-        \               <prim:k7>contemporary sociology journal of reviews</prim:k7>\n
-        \               <prim:k8>product review globalization from below transnational
-        activists protest networks</prim:k8>\n                <prim:k9>productreviewglobaliworks</prim:k9>\n
-        \               <prim:k12>productreviewglobalizatio</prim:k12>\n                <prim:k15>jsmith</prim:k15>\n
-        \               <prim:k16>smithj</prim:k16>\n              </prim:frbr>\n
+        \             </prim:links>\n              <prim:search>\n                <prim:scope>gale_onefilea</prim:scope>\n
+        \               <prim:scope>gale_onefileg</prim:scope>\n                <prim:creatorcontrib>Brecher,
+        Jeremy</prim:creatorcontrib>\n                <prim:creatorcontrib>Costello,
+        Tim</prim:creatorcontrib>\n                <prim:creatorcontrib>Smith, Brendan</prim:creatorcontrib>\n
+        \               <prim:title><![CDATA[<span class=\"searchword\">Globalization</span>
+        <span class=\"searchword\">From</span> <span class=\"searchword\">Below</span>
+        : INTERNATIONAL SOLIDARITY IS THE KEY TO CONSOLIDATING THE LEGACY OF SEATTLE.(grassroots
+        social movements)]]></prim:title>\n                <prim:subject>International
+        economic relations--Social aspects</prim:subject>\n                <prim:subject>Activists--Behavior</prim:subject>\n
+        \               <prim:subject>Environmentalism--Political aspects</prim:subject>\n
+        \               <prim:subject>Social movements--Political aspects</prim:subject>\n
+        \               <prim:subject>Feminism--Political aspects</prim:subject>\n
+        \               <prim:subject>Labor movement--Political aspects</prim:subject>\n
+        \               <prim:subject>00WOR</prim:subject>\n                <prim:subject>World</prim:subject>\n
+        \               <prim:subject>Demonstrations and protests</prim:subject>\n
+        \               <prim:subject>International Monetary Fund</prim:subject>\n
+        \               <prim:subject>World Trade Organization</prim:subject>\n                <prim:general>The
+        Nation Company L.P.</prim:general>\n                <prim:general>Cengage
+        Learning, Inc.</prim:general>\n                <prim:sourceid>gale_ofa</prim:sourceid>\n
+        \               <prim:recordid>gale_ofa67161994</prim:recordid>\n                <prim:issn>0027-8378</prim:issn>\n
+        \               <prim:issn>00278378</prim:issn>\n                <prim:rsrctype>article</prim:rsrctype>\n
+        \               <prim:creationdate>2000</prim:creationdate>\n                <prim:recordtype>article</prim:recordtype>\n
+        \               <prim:addtitle>The Nation</prim:addtitle>\n                <prim:searchscope>OneFile</prim:searchscope>\n
+        \               <prim:scope>OneFile</prim:scope>\n              </prim:search>\n
+        \             <prim:sort>\n                <prim:title>Globalization From
+        Below : INTERNATIONAL SOLIDARITY IS THE KEY TO CONSOLIDATING THE LEGACY OF
+        SEATTLE.(grassroots social movements)</prim:title>\n                <prim:author>Brecher,
+        Jeremy ; Costello, Tim ; Smith, Brendan</prim:author>\n                <prim:creationdate>20001204</prim:creationdate>\n
+        \             </prim:sort>\n              <prim:facets>\n                <prim:frbrgroupid>6516380186211662130</prim:frbrgroupid>\n
+        \               <prim:frbrtype>6</prim:frbrtype>\n                <prim:creationdate>2000</prim:creationdate>\n
+        \               <prim:topic>International Economic Relations–Social Aspects</prim:topic>\n
+        \               <prim:topic>Activists–Behavior</prim:topic>\n                <prim:topic>Environmentalism–Political
+        Aspects</prim:topic>\n                <prim:topic>Social Movements–Political
+        Aspects</prim:topic>\n                <prim:topic>Feminism–Political Aspects</prim:topic>\n
+        \               <prim:topic>Labor Movement–Political Aspects</prim:topic>\n
+        \               <prim:collection>OneFile (GALE)</prim:collection>\n                <prim:prefilter>articles</prim:prefilter>\n
+        \               <prim:rsrctype>articles</prim:rsrctype>\n                <prim:creatorcontrib>Brecher,
+        Jeremy</prim:creatorcontrib>\n                <prim:creatorcontrib>Costello,
+        Tim</prim:creatorcontrib>\n                <prim:creatorcontrib>Smith, Brendan</prim:creatorcontrib>\n
+        \               <prim:jtitle>The Nation</prim:jtitle>\n              </prim:facets>\n
+        \             <prim:frbr>\n                <prim:t>2</prim:t>\n                <prim:k1>2000</prim:k1>\n
+        \               <prim:k2>00278378</prim:k2>\n                <prim:k4>271</prim:k4>\n
+        \               <prim:k5>18</prim:k5>\n                <prim:k6>19</prim:k6>\n
+        \               <prim:k7>nation</prim:k7>\n                <prim:k8>globalization
+        from below international solidarity is the key to consolidating the legacy
+        of seattle</prim:k8>\n                <prim:k9>globalizationfrombelattle</prim:k9>\n
+        \               <prim:k12>globalizationfrombelowint</prim:k12>\n                <prim:k15>jeremybrecher</prim:k15>\n
+        \               <prim:k16>brecherjeremy</prim:k16>\n              </prim:frbr>\n
         \             <prim:delivery>\n                <prim:delcategory>Remote Search
         Resource</prim:delcategory>\n                <prim:fulltext>fulltext</prim:fulltext>\n
         \             </prim:delivery>\n              <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
-        \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>aggregator_crossref</prim:pcg_type>\n
-        \             </prim:ranking>\n              <prim:addata>\n                <prim:aulast>Smith</prim:aulast>\n
-        \               <prim:aufirst>J.</prim:aufirst>\n                <prim:au>Smith,
-        J.</prim:au>\n                <prim:atitle>Product Review: Globalization from
-        Below: Transnational Activists and Protest Networks</prim:atitle>\n                <prim:jtitle>Contemporary
-        Sociology: A Journal of Reviews</prim:jtitle>\n                <prim:date>20070301</prim:date>\n
-        \               <prim:risdate>20070301</prim:risdate>\n                <prim:volume>36</prim:volume>\n
-        \               <prim:issue>2</prim:issue>\n                <prim:spage>191</prim:spage>\n
-        \               <prim:epage>192</prim:epage>\n                <prim:issn>0094-3061</prim:issn>\n
-        \               <prim:eissn>0094-3061</prim:eissn>\n                <prim:genre>article</prim:genre>\n
-        \               <prim:ristype>JOUR</prim:ristype>\n                <prim:doi>10.1177/009430610603600252</prim:doi>\n
+        \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>aggregator</prim:pcg_type>\n
+        \             </prim:ranking>\n              <prim:addata>\n                <prim:au>Brecher,
+        Jeremy</prim:au>\n                <prim:au>Costello, Tim</prim:au>\n                <prim:au>Smith,
+        Brendan</prim:au>\n                <prim:atitle>Globalization From Below :
+        INTERNATIONAL SOLIDARITY IS THE KEY TO CONSOLIDATING THE LEGACY OF SEATTLE.(grassroots
+        social movements)</prim:atitle>\n                <prim:jtitle>The Nation</prim:jtitle>\n
+        \               <prim:date>20001204</prim:date>\n                <prim:risdate>20001204</prim:risdate>\n
+        \               <prim:volume>271</prim:volume>\n                <prim:issue>18</prim:issue>\n
+        \               <prim:spage>19</prim:spage>\n                <prim:issn>0027-8378</prim:issn>\n
+        \               <prim:genre>article</prim:genre>\n                <prim:ristype>JOUR</prim:ristype>\n
+        \               <prim:pub>The Nation Company L.P.</prim:pub>\n                <prim:lad01>gale_ofa</prim:lad01>\n
         \             </prim:addata>\n            </prim:record>\n          </prim:PrimoNMBib>\n
-        \         <sear:GETIT GetIt2=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-08-20T15%3A54%3A45IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert%2C%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft_id=info:oai/>\"
-        GetIt1=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-08-20T15%3A54%3A45IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert%2C%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft_id=info:oai/>\"
-        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-08-20T15%3A54%3A45IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Product%20Review:%20Globalization%20from%20Below:%20Transnational%20Activists%20and%20Protest%20Networks&rft.jtitle=Contemporary%20Sociology:%20A%20Journal%20of%20Reviews&rft.btitle=&rft.aulast=Smith&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Smith%2C%20J.&rft.aucorp=&rft.date=20070301&rft.volume=36&rft.issue=2&rft.part=&rft.quarter=&rft.ssn=&rft.spage=191&rft.epage=192&rft.pages=&rft.artnum=&rft.issn=0094-3061&rft.eissn=0094-3061&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1177/009430610603600252&rft.eisbn=&rft_dat=<crossref>10.1177/009430610603600252</crossref>&rft_id=info:oai/>]]></sear:openurl>\n
-        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-08-20T15%3A54%3A45IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Product%20Review:%20Globalization%20from%20Below:%20Transnational%20Activists%20and%20Protest%20Networks&rft.jtitle=Contemporary%20Sociology:%20A%20Journal%20of%20Reviews&rft.btitle=&rft.aulast=Smith&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Smith%2C%20J.&rft.aucorp=&rft.date=20070301&rft.volume=36&rft.issue=2&rft.part=&rft.quarter=&rft.ssn=&rft.spage=191&rft.epage=192&rft.pages=&rft.artnum=&rft.issn=0094-3061&rft.eissn=0094-3061&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1177/009430610603600252&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft.eisbn=&rft_dat=<crossref>10.1177/009430610603600252</crossref>&rft_id=info:oai/>]]></sear:openurlfulltext>\n
-        \           <sear:addlink>http://fe.p.prod.primo.saas.exlibrisgroup.com:1701/primo_library/libweb/aboutCrossref.html</sear:addlink>\n
+        \         <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20From%20Below%20:%20INTERNATIONAL%20SOLIDARITY%20IS%20THE%20KEY%20TO%20CONSOLIDATING%20THE%20LEGACY%20OF%20SEATTLE.(grassroots%20social%20movements)&rft.jtitle=The%20Nation&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Brecher,%20Jeremy&rft.aucorp=&rft.date=20001204&rft.volume=271&rft.issue=18&rft.part=&rft.quarter=&rft.ssn=&rft.spage=19&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0027-8378&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>67161994</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20From%20Below%20:%20INTERNATIONAL%20SOLIDARITY%20IS%20THE%20KEY%20TO%20CONSOLIDATING%20THE%20LEGACY%20OF%20SEATTLE.(grassroots%20social%20movements)&rft.jtitle=The%20Nation&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Brecher,%20Jeremy&rft.aucorp=&rft.date=20001204&rft.volume=271&rft.issue=18&rft.part=&rft.quarter=&rft.ssn=&rft.spage=19&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0027-8378&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>67161994</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20From%20Below%20:%20INTERNATIONAL%20SOLIDARITY%20IS%20THE%20KEY%20TO%20CONSOLIDATING%20THE%20LEGACY%20OF%20SEATTLE.(grassroots%20social%20movements)&rft.jtitle=The%20Nation&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Brecher,%20Jeremy&rft.aucorp=&rft.date=20001204&rft.volume=271&rft.issue=18&rft.part=&rft.quarter=&rft.ssn=&rft.spage=19&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0027-8378&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>67161994</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20From%20Below%20:%20INTERNATIONAL%20SOLIDARITY%20IS%20THE%20KEY%20TO%20CONSOLIDATING%20THE%20LEGACY%20OF%20SEATTLE.(grassroots%20social%20movements)&rft.jtitle=The%20Nation&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Brecher,%20Jeremy&rft.aucorp=&rft.date=20001204&rft.volume=271&rft.issue=18&rft.part=&rft.quarter=&rft.ssn=&rft.spage=19&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0027-8378&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>67161994</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
         \         </sear:LINKS>\n        </sear:DOC>\n        <sear:DOC LOCAL=\"false\"
         SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
-        NO=\"6\" RANK=\"0.027729223\" ID=\"185892779\">\n          <prim:PrimoNMBib
+        NO=\"8\" RANK=\"0.023009675\" ID=\"16897246\">\n          <prim:PrimoNMBib
         xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
         xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n            <prim:record>\n
-        \             <prim:control>\n                <prim:sourcerecordid>10.1177/009430610703600252</prim:sourcerecordid>\n
-        \               <prim:sourceid>crossref</prim:sourceid>\n                <prim:recordid>TN_crossref10.1177/009430610703600252</prim:recordid>\n
+        \             <prim:control>\n                <prim:sourcerecordid>141912918</prim:sourcerecordid>\n
+        \               <prim:sourceid>gale_ofa</prim:sourceid>\n                <prim:recordid>TN_gale_ofa141912918</prim:recordid>\n
         \               <prim:sourceformat>XML</prim:sourceformat>\n                <prim:sourcesystem>Other</prim:sourcesystem>\n
         \             </prim:control>\n              <prim:display>\n                <prim:type>article</prim:type>\n
         \               <prim:title><![CDATA[<span class=\"searchword\">Globalization</span>
         <span class=\"searchword\">from</span> <span class=\"searchword\">Below</span>:
-        Transnational Activists and Protest Networks]]></prim:title>\n                <prim:creator>Smith,
-        J.</prim:creator>\n                <prim:ispartof>Contemporary Sociology:
-        A Journal of Reviews, 2007, Vol.36(2), pp.191-192</prim:ispartof>\n                <prim:identifier>&lt;b>ISSN:&lt;/b>
-        0094-3061 ; &lt;b>DOI:&lt;/b> http://dx.doi.org/10.1177/009430610703600252</prim:identifier>\n
-        \               <prim:language>eng</prim:language>\n                <prim:source>Sage
-        Publications (via CrossRef)</prim:source>\n                <prim:lds50>peer_reviewed</prim:lds50>\n
-        \               <prim:version>2</prim:version>\n                <prim:snippetfield>title</prim:snippetfield>\n
-        \               <prim:snippet><![CDATA[<span class=\"searchword\">Globalization</span>
-        <span class=\"searchword\">from</span> <span class=\"searchword\">Below</span>:
-        Transnational Activists and Protest Networks]]></prim:snippet>\n              </prim:display>\n
+        The Ranking of Global Immigrant Cities.(Debates and Developments)(Author Abstract)]]></prim:title>\n
+        \               <prim:creator>Benton - Short, Lisa ; Price, Marie D. ; Friedman,
+        Samantha</prim:creator>\n                <prim:ispartof>International Journal
+        of Urban and Regional Research, Dec, 2005, Vol.29(4), p.945-959</prim:ispartof>\n
+        \               <prim:identifier>&lt;b>ISSN: &lt;/b>0309-1317</prim:identifier>\n
+        \               <prim:subject>&lt;span class=\"searchword\">Globalization&lt;/span>
+        -- Economic Aspects ; &lt;span class=\"searchword\">Globalization&lt;/span>
+        -- Social Aspects ; &lt;span class=\"searchword\">Globalization&lt;/span>
+        -- Political Aspects ; Metropolitan Areas -- International Aspects ; Metropolitan
+        Areas -- Economic Aspects ; Metropolitan Areas -- Social Aspects ; Metropolitan
+        Areas -- Political Aspects ; Multiculturalism -- Research ; Multiculturalism
+        -- Comparative Analysis</prim:subject>\n                <prim:description>Immigration
+        to major cities is an important dimension of cultural &lt;span class=\"searchword\">globalization&lt;/span>,
+        one that has been largely ignored in the global cities literature. Rates of
+        immigration to major world cities are an important indicator of global city
+        status and should be included in determining urban hierarchy indexes. Our
+        study considers immigration in more than 100 metropolitan areas, using data
+        &lt;span class=\"searchword\">from&lt;/span> national censuses &lt;span class=\"searchword\">from&lt;/span>
+        more than 50 countries. We rank major cities of immigration and compare them
+        to well-known global city hierarchies. Using immigration data, we create an
+        urban immigrant index. The index considers four factors of immigration: (1)
+        the percentage of foreign-born, (2) the total number of foreign-born, (3)
+        the diversity of the foreign-born stock, and (4) whether immigrants are &lt;span
+        class=\"searchword\">from&lt;/span> neighboring countries or non-neighboring
+        countries. This is the first time that an international urban immigrant data
+        set and index have been created. The study explains the empirical challenge
+        of acquiring comparable international metropolitan data and the limits of
+        this research. Some of the cities that rank highly in the index are commonly
+        cited as world cities (London, New York and Frankfurt); others such as Toronto,
+        Amsterdam and Dubai seldom appear so highly ranked.</prim:description>\n                <prim:language>English</prim:language>\n
+        \               <prim:source>Cengage Learning, Inc.</prim:source>\n                <prim:lds50>peer_reviewed</prim:lds50>\n
+        \               <prim:version>4</prim:version>\n                <prim:snippetfield>subject</prim:snippetfield>\n
+        \               <prim:snippetfield>subject</prim:snippetfield>\n                <prim:snippetfield>description</prim:snippetfield>\n
+        \               <prim:snippetfield>description</prim:snippetfield>\n                <prim:snippetfield>description</prim:snippetfield>\n
+        \               <prim:snippetfield>subject</prim:snippetfield>\n                <prim:snippetfield>description</prim:snippetfield>\n
+        \               <prim:snippetfield>title</prim:snippetfield>\n                <prim:snippet>&lt;span
+        class=\"searchword\">Globalization&lt;/span>--Economic aspects... &lt;span
+        class=\"searchword\">Globalization&lt;/span>--Social aspects...  censuses
+        &lt;span class=\"searchword\">from&lt;/span> more than 50 countries. We rank
+        major cities of immigration and compare them to well-known global city hierarchies.
+        Using immigration data, we create an urban immigrant index. The index... Immigration
+        to major cities is an important dimension of cultural &lt;span class=\"searchword\">globalization&lt;/span>,
+        one that has been largely ignored in the global cities literature. Rates of
+        immigration to major world cities...  are an important indicator of global
+        city status and should be included in determining urban hierarchy indexes.
+        Our study considers immigration in more than 100 metropolitan areas, using
+        data &lt;span class=\"searchword\">from&lt;/span> national... &lt;span class=\"searchword\">Globalization&lt;/span>--Political
+        aspects...  considers four factors of immigration: (1) the percentage of foreign-born,
+        (2) the total number of foreign-born, (3) the diversity of the foreign-born
+        stock, and (4) whether immigrants are &lt;span class=\"searchword\">from&lt;/span>...
+        &lt;span class=\"searchword\">Globalization&lt;/span> &lt;span class=\"searchword\">from&lt;/span>
+        &lt;span class=\"searchword\">Below&lt;/span>: The Ranking of Global Immigrant
+        Cities.(Debates and Developments)(Author Abstract)</prim:snippet>\n              </prim:display>\n
         \             <prim:links>\n                <prim:openurl>$$Topenurl_article</prim:openurl>\n
         \               <prim:openurlfulltext>$$Topenurlfull_article</prim:openurlfulltext>\n
-        \               <prim:addlink>$$Uhttp://fe.p.prod.primo.saas.exlibrisgroup.com:1701/primo_library/libweb/aboutCrossref.html$$DView
-        CrossRef copyright notice</prim:addlink>\n              </prim:links>\n              <prim:search>\n
-        \               <prim:creatorcontrib>Smith, J.</prim:creatorcontrib>\n                <prim:title><![CDATA[<span
-        class=\"searchword\">Globalization</span> <span class=\"searchword\">from</span>
-        <span class=\"searchword\">Below</span>: Transnational Activists and Protest
-        Networks]]></prim:title>\n                <prim:general>English</prim:general>\n
-        \               <prim:general>10.1177/009430610703600252</prim:general>\n
-        \               <prim:sourceid>crossref</prim:sourceid>\n                <prim:recordid>crossref10.1177/009430610703600252</prim:recordid>\n
-        \               <prim:issn>0094-3061</prim:issn>\n                <prim:issn>00943061</prim:issn>\n
-        \               <prim:rsrctype>article</prim:rsrctype>\n                <prim:creationdate>2007</prim:creationdate>\n
-        \               <prim:addtitle>Contemporary Sociology: A Journal of Reviews</prim:addtitle>\n
-        \               <prim:searchscope>crossref_sp</prim:searchscope>\n                <prim:searchscope>CrossRef</prim:searchscope>\n
-        \               <prim:searchscope>Crossref</prim:searchscope>\n                <prim:searchscope>crossref</prim:searchscope>\n
-        \               <prim:scope>crossref_sp</prim:scope>\n                <prim:scope>CrossRef</prim:scope>\n
-        \               <prim:scope>Crossref</prim:scope>\n                <prim:scope>crossref</prim:scope>\n
-        \             </prim:search>\n              <prim:sort>\n                <prim:title>Globalization
-        from Below: Transnational Activists and Protest Networks</prim:title>\n                <prim:author>Smith,
-        J.</prim:author>\n                <prim:creationdate>20070301</prim:creationdate>\n
-        \             </prim:sort>\n              <prim:facets>\n                <prim:language>eng</prim:language>\n
-        \               <prim:creationdate>2007</prim:creationdate>\n                <prim:collection>Sage
-        Publications (CrossRef)</prim:collection>\n                <prim:prefilter>articles</prim:prefilter>\n
-        \               <prim:rsrctype>articles</prim:rsrctype>\n                <prim:creatorcontrib>Smith,
-        J.</prim:creatorcontrib>\n                <prim:jtitle>Contemporary Sociology:
-        A Journal Of Reviews</prim:jtitle>\n                <prim:toplevel>peer_reviewed</prim:toplevel>\n
-        \               <prim:frbrgroupid>8392744814617276471</prim:frbrgroupid>\n
-        \               <prim:frbrtype>5</prim:frbrtype>\n              </prim:facets>\n
-        \             <prim:frbr>\n                <prim:t>2</prim:t>\n                <prim:k1>2007</prim:k1>\n
-        \               <prim:k2>00943061</prim:k2>\n                <prim:k3>10.1177/009430610703600252</prim:k3>\n
-        \               <prim:k4>36</prim:k4>\n                <prim:k5>2</prim:k5>\n
-        \               <prim:k6>191</prim:k6>\n                <prim:k7>contemporary
-        sociology journal of reviews</prim:k7>\n                <prim:k8>globalization
-        from below transnational activists protest networks</prim:k8>\n                <prim:k9>globalizationfrombelworks</prim:k9>\n
-        \               <prim:k12>globalizationfrombelowtra</prim:k12>\n                <prim:k15>jsmith</prim:k15>\n
-        \               <prim:k16>smithj</prim:k16>\n              </prim:frbr>\n
+        \             </prim:links>\n              <prim:search>\n                <prim:scope>gale_onefileg</prim:scope>\n
+        \               <prim:scope>gale_onefilea</prim:scope>\n                <prim:creatorcontrib>Benton-Short,
+        Lisa</prim:creatorcontrib>\n                <prim:creatorcontrib>Price, Marie
+        D</prim:creatorcontrib>\n                <prim:creatorcontrib>Friedman, Samantha</prim:creatorcontrib>\n
+        \               <prim:title><![CDATA[<span class=\"searchword\">Globalization</span>
+        <span class=\"searchword\">from</span> <span class=\"searchword\">Below</span>:
+        The Ranking of Global Immigrant Cities.(Debates and Developments)(Author Abstract)]]></prim:title>\n
+        \               <prim:description>Immigration to major cities is an important
+        dimension of cultural globalization, one that has been largely ignored in
+        the global cities literature. Rates of immigration to major world cities are
+        an important indicator of global city status and should be included in determining
+        urban hierarchy indexes. Our study considers immigration in more than 100
+        metropolitan areas, using data from national censuses from more than 50 countries.
+        We rank major cities of immigration and compare them to well-known global
+        city hierarchies. Using immigration data, we create an urban immigrant index.
+        The index considers four factors of immigration: (1) the percentage of foreign-born,
+        (2) the total number of foreign-born, (3) the diversity of the foreign-born
+        stock, and (4) whether immigrants are from neighboring countries or non-neighboring
+        countries. This is the first time that an international urban immigrant data
+        set and index have been created. The study explains the empirical challenge
+        of acquiring comparable international metropolitan data and the limits of
+        this research. Some of the cities that rank highly in the index are commonly
+        cited as world cities (London, New York and Frankfurt); others such as Toronto,
+        Amsterdam and Dubai seldom appear so highly ranked.</prim:description>\n                <prim:subject>Globalization--Economic
+        aspects</prim:subject>\n                <prim:subject>Globalization--Social
+        aspects</prim:subject>\n                <prim:subject>Globalization--Political
+        aspects</prim:subject>\n                <prim:subject>Metropolitan areas--International
+        aspects</prim:subject>\n                <prim:subject>Metropolitan areas--Economic
+        aspects</prim:subject>\n                <prim:subject>Metropolitan areas--Social
+        aspects</prim:subject>\n                <prim:subject>Metropolitan areas--Political
+        aspects</prim:subject>\n                <prim:subject>Multiculturalism--Research</prim:subject>\n
+        \               <prim:subject>Multiculturalism--Comparative analysis</prim:subject>\n
+        \               <prim:general>English</prim:general>\n                <prim:general>Blackwell
+        Publishers Ltd.</prim:general>\n                <prim:general>Cengage Learning,
+        Inc.</prim:general>\n                <prim:sourceid>gale_ofa</prim:sourceid>\n
+        \               <prim:recordid>gale_ofa141912918</prim:recordid>\n                <prim:issn>0309-1317</prim:issn>\n
+        \               <prim:issn>03091317</prim:issn>\n                <prim:rsrctype>article</prim:rsrctype>\n
+        \               <prim:creationdate>2005</prim:creationdate>\n                <prim:recordtype>article</prim:recordtype>\n
+        \               <prim:addtitle>International Journal of Urban and Regional
+        Research</prim:addtitle>\n                <prim:searchscope>OneFile</prim:searchscope>\n
+        \               <prim:scope>OneFile</prim:scope>\n              </prim:search>\n
+        \             <prim:sort>\n                <prim:title>Globalization from
+        Below: The Ranking of Global Immigrant Cities.(Debates and Developments)(Author
+        Abstract)</prim:title>\n                <prim:author>Benton - Short, Lisa
+        ; Price, Marie D. ; Friedman, Samantha</prim:author>\n                <prim:creationdate>20051201</prim:creationdate>\n
+        \             </prim:sort>\n              <prim:facets>\n                <prim:frbrgroupid>6564571683546004021</prim:frbrgroupid>\n
+        \               <prim:frbrtype>5</prim:frbrtype>\n                <prim:language>eng</prim:language>\n
+        \               <prim:creationdate>2005</prim:creationdate>\n                <prim:topic>Globalization–Economic
+        Aspects</prim:topic>\n                <prim:topic>Globalization–Social Aspects</prim:topic>\n
+        \               <prim:topic>Globalization–Political Aspects</prim:topic>\n
+        \               <prim:topic>Metropolitan Areas–International Aspects</prim:topic>\n
+        \               <prim:topic>Metropolitan Areas–Economic Aspects</prim:topic>\n
+        \               <prim:topic>Metropolitan Areas–Social Aspects</prim:topic>\n
+        \               <prim:topic>Metropolitan Areas–Political Aspects</prim:topic>\n
+        \               <prim:topic>Multiculturalism–Research</prim:topic>\n                <prim:topic>Multiculturalism–Comparative
+        Analysis</prim:topic>\n                <prim:collection>OneFile (GALE)</prim:collection>\n
+        \               <prim:prefilter>articles</prim:prefilter>\n                <prim:rsrctype>articles</prim:rsrctype>\n
+        \               <prim:creatorcontrib>Benton - Short, Lisa</prim:creatorcontrib>\n
+        \               <prim:creatorcontrib>Price, Marie D.</prim:creatorcontrib>\n
+        \               <prim:creatorcontrib>Friedman, Samantha</prim:creatorcontrib>\n
+        \               <prim:jtitle>International Journal of Urban and Regional Research</prim:jtitle>\n
+        \               <prim:toplevel>peer_reviewed</prim:toplevel>\n              </prim:facets>\n
+        \             <prim:frbr>\n                <prim:t>2</prim:t>\n                <prim:k1>2005</prim:k1>\n
+        \               <prim:k2>03091317</prim:k2>\n                <prim:k4>29</prim:k4>\n
+        \               <prim:k5>4</prim:k5>\n                <prim:k6>945</prim:k6>\n
+        \               <prim:k7>international journal of urban regional research</prim:k7>\n
+        \               <prim:k8>globalization from below the ranking of global immigrant
+        cities</prim:k8>\n                <prim:k9>globalizationfrombelities</prim:k9>\n
+        \               <prim:k12>globalizationfrombelowthe</prim:k12>\n                <prim:k15>lisabentonshort</prim:k15>\n
+        \               <prim:k16>bentonshortlisa</prim:k16>\n              </prim:frbr>\n
         \             <prim:delivery>\n                <prim:delcategory>Remote Search
         Resource</prim:delcategory>\n                <prim:fulltext>fulltext</prim:fulltext>\n
         \             </prim:delivery>\n              <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
-        \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>aggregator_crossref</prim:pcg_type>\n
-        \             </prim:ranking>\n              <prim:addata>\n                <prim:aulast>Smith</prim:aulast>\n
-        \               <prim:aufirst>J.</prim:aufirst>\n                <prim:au>Smith,
-        J.</prim:au>\n                <prim:atitle>Globalization from Below: Transnational
-        Activists and Protest Networks</prim:atitle>\n                <prim:jtitle>Contemporary
-        Sociology: A Journal of Reviews</prim:jtitle>\n                <prim:date>20070301</prim:date>\n
-        \               <prim:risdate>20070301</prim:risdate>\n                <prim:volume>36</prim:volume>\n
-        \               <prim:issue>2</prim:issue>\n                <prim:spage>191</prim:spage>\n
-        \               <prim:epage>192</prim:epage>\n                <prim:issn>0094-3061</prim:issn>\n
-        \               <prim:eissn>0094-3061</prim:eissn>\n                <prim:genre>article</prim:genre>\n
-        \               <prim:ristype>JOUR</prim:ristype>\n                <prim:doi>10.1177/009430610703600252</prim:doi>\n
+        \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>aggregator</prim:pcg_type>\n
+        \             </prim:ranking>\n              <prim:addata>\n                <prim:au>Benton-Short,
+        Lisa</prim:au>\n                <prim:au>Price, Marie D.</prim:au>\n                <prim:au>Friedman,
+        Samantha</prim:au>\n                <prim:atitle>Globalization from Below:
+        The Ranking of Global Immigrant Cities.(Debates and Developments)(Author Abstract)</prim:atitle>\n
+        \               <prim:jtitle>International Journal of Urban and Regional Research</prim:jtitle>\n
+        \               <prim:date>20051201</prim:date>\n                <prim:risdate>20051201</prim:risdate>\n
+        \               <prim:volume>29</prim:volume>\n                <prim:issue>4</prim:issue>\n
+        \               <prim:spage>945-959</prim:spage>\n                <prim:issn>0309-1317</prim:issn>\n
+        \               <prim:genre>article</prim:genre>\n                <prim:ristype>JOUR</prim:ristype>\n
+        \               <prim:abstract>Immigration to major cities is an important
+        dimension of cultural globalization, one that has been largely ignored in
+        the global cities literature. Rates of immigration to major world cities are
+        an important indicator of global city status and should be included in determining
+        urban hierarchy indexes. Our study considers immigration in more than 100
+        metropolitan areas, using data from national censuses from more than 50 countries.
+        We rank major cities of immigration and compare them to well-known global
+        city hierarchies. Using immigration data, we create an urban immigrant index.
+        The index considers four factors of immigration: (1) the percentage of foreign-born,
+        (2) the total number of foreign-born, (3) the diversity of the foreign-born
+        stock, and (4) whether immigrants are from neighboring countries or non-neighboring
+        countries. This is the first time that an international urban immigrant data
+        set and index have been created. The study explains the empirical challenge
+        of acquiring comparable international metropolitan data and the limits of
+        this research. Some of the cities that rank highly in the index are commonly
+        cited as world cities (London, New York and Frankfurt); others such as Toronto,
+        Amsterdam and Dubai seldom appear so highly ranked.</prim:abstract>\n                <prim:pub>Blackwell
+        Publishers Ltd.</prim:pub>\n                <prim:lad01>gale_ofa</prim:lad01>\n
         \             </prim:addata>\n            </prim:record>\n          </prim:PrimoNMBib>\n
-        \         <sear:GETIT GetIt2=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-08-20T15%3A54%3A45IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert%2C%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft_id=info:oai/>\"
-        GetIt1=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-08-20T15%3A54%3A45IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert%2C%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft_id=info:oai/>\"
-        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-08-20T15%3A54%3A45IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20Transnational%20Activists%20and%20Protest%20Networks&rft.jtitle=Contemporary%20Sociology:%20A%20Journal%20of%20Reviews&rft.btitle=&rft.aulast=Smith&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Smith%2C%20J.&rft.aucorp=&rft.date=20070301&rft.volume=36&rft.issue=2&rft.part=&rft.quarter=&rft.ssn=&rft.spage=191&rft.epage=192&rft.pages=&rft.artnum=&rft.issn=0094-3061&rft.eissn=0094-3061&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1177/009430610703600252&rft.eisbn=&rft_dat=<crossref>10.1177/009430610703600252</crossref>&rft_id=info:oai/>]]></sear:openurl>\n
-        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-08-20T15%3A54%3A45IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20Transnational%20Activists%20and%20Protest%20Networks&rft.jtitle=Contemporary%20Sociology:%20A%20Journal%20of%20Reviews&rft.btitle=&rft.aulast=Smith&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Smith%2C%20J.&rft.aucorp=&rft.date=20070301&rft.volume=36&rft.issue=2&rft.part=&rft.quarter=&rft.ssn=&rft.spage=191&rft.epage=192&rft.pages=&rft.artnum=&rft.issn=0094-3061&rft.eissn=0094-3061&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1177/009430610703600252&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft.eisbn=&rft_dat=<crossref>10.1177/009430610703600252</crossref>&rft_id=info:oai/>]]></sear:openurlfulltext>\n
-        \           <sear:addlink>http://fe.p.prod.primo.saas.exlibrisgroup.com:1701/primo_library/libweb/aboutCrossref.html</sear:addlink>\n
+        \         <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20The%20Ranking%20of%20Global%20Immigrant%20Cities.(Debates%20and%20Developments)(Author%20Abstract)&rft.jtitle=International%20Journal%20of%20Urban%20and%20Regional%20Research&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Benton-Short,%20Lisa&rft.aucorp=&rft.date=20051201&rft.volume=29&rft.issue=4&rft.part=&rft.quarter=&rft.ssn=&rft.spage=945-959&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0309-1317&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>141912918</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20The%20Ranking%20of%20Global%20Immigrant%20Cities.(Debates%20and%20Developments)(Author%20Abstract)&rft.jtitle=International%20Journal%20of%20Urban%20and%20Regional%20Research&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Benton-Short,%20Lisa&rft.aucorp=&rft.date=20051201&rft.volume=29&rft.issue=4&rft.part=&rft.quarter=&rft.ssn=&rft.spage=945-959&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0309-1317&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>141912918</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20The%20Ranking%20of%20Global%20Immigrant%20Cities.(Debates%20and%20Developments)(Author%20Abstract)&rft.jtitle=International%20Journal%20of%20Urban%20and%20Regional%20Research&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Benton-Short,%20Lisa&rft.aucorp=&rft.date=20051201&rft.volume=29&rft.issue=4&rft.part=&rft.quarter=&rft.ssn=&rft.spage=945-959&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0309-1317&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&rft_dat=<gale_ofa>141912918</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20The%20Ranking%20of%20Global%20Immigrant%20Cities.(Debates%20and%20Developments)(Author%20Abstract)&rft.jtitle=International%20Journal%20of%20Urban%20and%20Regional%20Research&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Benton-Short,%20Lisa&rft.aucorp=&rft.date=20051201&rft.volume=29&rft.issue=4&rft.part=&rft.quarter=&rft.ssn=&rft.spage=945-959&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0309-1317&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<gale_ofa>141912918</gale_ofa>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
         \         </sear:LINKS>\n        </sear:DOC>\n        <sear:DOC LOCAL=\"false\"
         SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
-        NO=\"7\" RANK=\"0.022833783\" ID=\"235993978\">\n          <prim:PrimoNMBib
+        NO=\"9\" RANK=\"0.022914143\" ID=\"123050971\">\n          <prim:PrimoNMBib
         xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
         xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n            <prim:record>\n
         \             <prim:control>\n                <prim:sourcerecordid>10.1093/rsq/hdq006</prim:sourcerecordid>\n
@@ -876,12 +1347,12 @@ http_interactions:
         Criminal Law as a Governance Strategy in the Global Labour Market: Criminalizing
         Globalization from Below</prim:title>\n                <prim:author>Guilfoyle,
         Douglas</prim:author>\n                <prim:creationdate>20100800</prim:creationdate>\n
-        \             </prim:sort>\n              <prim:facets>\n                <prim:creationdate>2010</prim:creationdate>\n
+        \             </prim:sort>\n              <prim:facets>\n                <prim:frbrgroupid>7872359519687203846</prim:frbrgroupid>\n
+        \               <prim:frbrtype>6</prim:frbrtype>\n                <prim:creationdate>2010</prim:creationdate>\n
         \               <prim:collection>Oxford Journals (Oxford University Press)</prim:collection>\n
         \               <prim:prefilter>articles</prim:prefilter>\n                <prim:rsrctype>articles</prim:rsrctype>\n
         \               <prim:creatorcontrib>Guilfoyle, Douglas</prim:creatorcontrib>\n
         \               <prim:jtitle>Refugee Survey Quarterly</prim:jtitle>\n                <prim:toplevel>peer_reviewed</prim:toplevel>\n
-        \               <prim:frbrgroupid>513970567</prim:frbrgroupid>\n                <prim:frbrtype>6</prim:frbrtype>\n
         \             </prim:facets>\n              <prim:frbr>\n                <prim:t>2</prim:t>\n
         \               <prim:k1>2010</prim:k1>\n                <prim:k2>10204067</prim:k2>\n
         \               <prim:k2>1471695X</prim:k2>\n                <prim:k3>10.1093/rsq/hdq006</prim:k3>\n
@@ -905,7 +1376,7 @@ http_interactions:
         \               <prim:volume>29</prim:volume>\n                <prim:issue>1</prim:issue>\n
         \               <prim:spage>185</prim:spage>\n                <prim:epage>205</prim:epage>\n
         \               <prim:pages>185-205</prim:pages>\n                <prim:issn>1020-4067</prim:issn>\n
-        \               <prim:eissn>1471-695X</prim:eissn>\n                <prim:format>journal</prim:format>\n
+        \               <prim:eissn>1471-695X</prim:eissn>\n                <prim:format>article</prim:format>\n
         \               <prim:genre>article</prim:genre>\n                <prim:ristype>JOUR</prim:ristype>\n
         \               <prim:abstract>This article examines the consequence of treating
         irregular labour migration as a criminal law issue, rather than one of trade
@@ -935,13 +1406,17 @@ http_interactions:
         argument.</prim:abstract>\n                <prim:pub>Oxford University Press</prim:pub>\n
         \               <prim:doi>10.1093/rsq/hdq006</prim:doi>\n              </prim:addata>\n
         \           </prim:record>\n          </prim:PrimoNMBib>\n          <sear:GETIT
-        GetIt2=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-08-20T15%3A54%3A45IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert%2C%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft_id=info:oai/>\"
-        GetIt1=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-08-20T15%3A54%3A45IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert%2C%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft_id=info:oai/>\"
-        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-08-20T15%3A54%3A45IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-oxford&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Transnational%20Criminal%20Law%20as%20a%20Governance%20Strategy%20in%20the%20Global%20Labour%20Market:%20Criminalizing%20Globalization%20from%20Below&rft.jtitle=Refugee%20Survey%20Quarterly&rft.btitle=&rft.aulast=Guilfoyle&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Guilfoyle%2C%20Douglas&rft.aucorp=&rft.date=201008&rft.volume=29&rft.issue=1&rft.part=&rft.quarter=&rft.ssn=&rft.spage=185&rft.epage=205&rft.pages=185-205&rft.artnum=&rft.issn=1020-4067&rft.eissn=1471-695X&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1093/rsq/hdq006&rft.eisbn=&rft_dat=<oxford>10.1093/rsq/hdq006</oxford>&rft_id=info:oai/>]]></sear:openurl>\n
-        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-08-20T15%3A54%3A45IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-oxford&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Transnational%20Criminal%20Law%20as%20a%20Governance%20Strategy%20in%20the%20Global%20Labour%20Market:%20Criminalizing%20Globalization%20from%20Below&rft.jtitle=Refugee%20Survey%20Quarterly&rft.btitle=&rft.aulast=Guilfoyle&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Guilfoyle%2C%20Douglas&rft.aucorp=&rft.date=201008&rft.volume=29&rft.issue=1&rft.part=&rft.quarter=&rft.ssn=&rft.spage=185&rft.epage=205&rft.pages=185-205&rft.artnum=&rft.issn=1020-4067&rft.eissn=1471-695X&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1093/rsq/hdq006&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft.eisbn=&rft_dat=<oxford>10.1093/rsq/hdq006</oxford>&rft_id=info:oai/>]]></sear:openurlfulltext>\n
+        GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-oxford&rft_val_fmt=info:ofi/fmt:kev:mtx:article&rft.genre=article&rft.atitle=Transnational%20Criminal%20Law%20as%20a%20Governance%20Strategy%20in%20the%20Global%20Labour%20Market:%20Criminalizing%20Globalization%20from%20Below&rft.jtitle=Refugee%20Survey%20Quarterly&rft.btitle=&rft.aulast=Guilfoyle&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Guilfoyle,%20Douglas&rft.aucorp=&rft.date=201008&rft.volume=29&rft.issue=1&rft.part=&rft.quarter=&rft.ssn=&rft.spage=185&rft.epage=205&rft.pages=185-205&rft.artnum=&rft.issn=1020-4067&rft.eissn=1471-695X&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1093/rsq/hdq006&rft.object_id=&rft_dat=<oxford>10.1093/rsq/hdq006</oxford>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-oxford&rft_val_fmt=info:ofi/fmt:kev:mtx:article&rft.genre=article&rft.atitle=Transnational%20Criminal%20Law%20as%20a%20Governance%20Strategy%20in%20the%20Global%20Labour%20Market:%20Criminalizing%20Globalization%20from%20Below&rft.jtitle=Refugee%20Survey%20Quarterly&rft.btitle=&rft.aulast=Guilfoyle&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Guilfoyle,%20Douglas&rft.aucorp=&rft.date=201008&rft.volume=29&rft.issue=1&rft.part=&rft.quarter=&rft.ssn=&rft.spage=185&rft.epage=205&rft.pages=185-205&rft.artnum=&rft.issn=1020-4067&rft.eissn=1471-695X&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1093/rsq/hdq006&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<oxford>10.1093/rsq/hdq006</oxford>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-oxford&rft_val_fmt=info:ofi/fmt:kev:mtx:article&rft.genre=article&rft.atitle=Transnational%20Criminal%20Law%20as%20a%20Governance%20Strategy%20in%20the%20Global%20Labour%20Market:%20Criminalizing%20Globalization%20from%20Below&rft.jtitle=Refugee%20Survey%20Quarterly&rft.btitle=&rft.aulast=Guilfoyle&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Guilfoyle,%20Douglas&rft.aucorp=&rft.date=201008&rft.volume=29&rft.issue=1&rft.part=&rft.quarter=&rft.ssn=&rft.spage=185&rft.epage=205&rft.pages=185-205&rft.artnum=&rft.issn=1020-4067&rft.eissn=1471-695X&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1093/rsq/hdq006&rft.object_id=&rft_dat=<oxford>10.1093/rsq/hdq006</oxford>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-oxford&rft_val_fmt=info:ofi/fmt:kev:mtx:article&rft.genre=article&rft.atitle=Transnational%20Criminal%20Law%20as%20a%20Governance%20Strategy%20in%20the%20Global%20Labour%20Market:%20Criminalizing%20Globalization%20from%20Below&rft.jtitle=Refugee%20Survey%20Quarterly&rft.btitle=&rft.aulast=Guilfoyle&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Guilfoyle,%20Douglas&rft.aucorp=&rft.date=201008&rft.volume=29&rft.issue=1&rft.part=&rft.quarter=&rft.ssn=&rft.spage=185&rft.epage=205&rft.pages=185-205&rft.artnum=&rft.issn=1020-4067&rft.eissn=1471-695X&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1093/rsq/hdq006&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<oxford>10.1093/rsq/hdq006</oxford>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
         \         </sear:LINKS>\n        </sear:DOC>\n        <sear:DOC LOCAL=\"false\"
         SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
-        NO=\"8\" RANK=\"0.022276655\" ID=\"81774878\">\n          <prim:PrimoNMBib
+        NO=\"10\" RANK=\"0.022450292\" ID=\"12272624\">\n          <prim:PrimoNMBib
         xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
         xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n            <prim:record>\n
         \             <prim:control>\n                <prim:sourcerecordid>10.1111/j.1468-2427.2005.00630.x</prim:sourcerecordid>\n
@@ -994,7 +1469,7 @@ http_interactions:
         (Londres, New York et Frankfort), d’autres comme Toronto, Amsterdam et Dubaï
         apparaissent rarement à ce niveau de classement.</prim:description>\n                <prim:source>John
         Wiley &amp; Sons, Inc.</prim:source>\n                <prim:lds50>peer_reviewed</prim:lds50>\n
-        \               <prim:version>3</prim:version>\n                <prim:snippetfield>description</prim:snippetfield>\n
+        \               <prim:version>4</prim:version>\n                <prim:snippetfield>description</prim:snippetfield>\n
         \               <prim:snippetfield>description</prim:snippetfield>\n                <prim:snippetfield>description</prim:snippetfield>\n
         \               <prim:snippetfield>description</prim:snippetfield>\n                <prim:snippetfield>title</prim:snippetfield>\n
         \               <prim:snippet>considers four factors of immigration: (1) the
@@ -1069,15 +1544,15 @@ http_interactions:
         \             <prim:sort>\n                <prim:title>Globalization from
         Below: The Ranking of Global Immigrant Cities</prim:title>\n                <prim:author>Benton‐short,
         Lisa ; Price, Marie D. ; Friedman, Samantha</prim:author>\n                <prim:creationdate>20051200</prim:creationdate>\n
-        \             </prim:sort>\n              <prim:facets>\n                <prim:creationdate>2005</prim:creationdate>\n
+        \             </prim:sort>\n              <prim:facets>\n                <prim:frbrgroupid>6564571683546004021</prim:frbrgroupid>\n
+        \               <prim:frbrtype>5</prim:frbrtype>\n                <prim:creationdate>2005</prim:creationdate>\n
         \               <prim:collection>Wiley Online Library</prim:collection>\n
         \               <prim:prefilter>articles</prim:prefilter>\n                <prim:rsrctype>articles</prim:rsrctype>\n
         \               <prim:creatorcontrib>Benton‐short, Lisa</prim:creatorcontrib>\n
         \               <prim:creatorcontrib>Price, Marie D.</prim:creatorcontrib>\n
         \               <prim:creatorcontrib>Friedman, Samantha</prim:creatorcontrib>\n
         \               <prim:jtitle>International Journal of Urban and Regional Research</prim:jtitle>\n
-        \               <prim:toplevel>peer_reviewed</prim:toplevel>\n                <prim:frbrgroupid>5601034458896755094</prim:frbrgroupid>\n
-        \               <prim:frbrtype>5</prim:frbrtype>\n              </prim:facets>\n
+        \               <prim:toplevel>peer_reviewed</prim:toplevel>\n              </prim:facets>\n
         \             <prim:frbr>\n                <prim:t>2</prim:t>\n                <prim:k1>2005</prim:k1>\n
         \               <prim:k2>03091317</prim:k2>\n                <prim:k2>14682427</prim:k2>\n
         \               <prim:k3>10.1111/j.1468-2427.2005.00630.x</prim:k3>\n                <prim:k4>29</prim:k4>\n
@@ -1144,148 +1619,16 @@ http_interactions:
         USA</prim:cop>\n                <prim:pub>Blackwell Publishing Ltd.</prim:pub>\n
         \               <prim:doi>10.1111/j.1468-2427.2005.00630.x</prim:doi>\n              </prim:addata>\n
         \           </prim:record>\n          </prim:PrimoNMBib>\n          <sear:GETIT
-        GetIt2=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-08-20T15%3A54%3A45IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert%2C%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft_id=info:oai/>\"
-        GetIt1=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-08-20T15%3A54%3A45IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert%2C%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft_id=info:oai/>\"
-        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-08-20T15%3A54%3A45IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-wj&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20The%20Ranking%20of%20Global%20Immigrant%20Cities&rft.jtitle=International%20Journal%20of%20Urban%20and%20Regional%20Research&rft.btitle=&rft.aulast=BENTON‐SHORT&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Benton‐short%2C%20Lisa&rft.aucorp=&rft.date=200512&rft.volume=29&rft.issue=4&rft.part=&rft.quarter=&rft.ssn=&rft.spage=945&rft.epage=959&rft.pages=&rft.artnum=&rft.issn=0309-1317&rft.eissn=1468-2427&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1111/j.1468-2427.2005.00630.x&rft.eisbn=&rft_dat=<wj>10.1111/j.1468-2427.2005.00630.x</wj>&rft_id=info:oai/>]]></sear:openurl>\n
-        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-08-20T15%3A54%3A45IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-wj&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20The%20Ranking%20of%20Global%20Immigrant%20Cities&rft.jtitle=International%20Journal%20of%20Urban%20and%20Regional%20Research&rft.btitle=&rft.aulast=BENTON‐SHORT&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Benton‐short%2C%20Lisa&rft.aucorp=&rft.date=200512&rft.volume=29&rft.issue=4&rft.part=&rft.quarter=&rft.ssn=&rft.spage=945&rft.epage=959&rft.pages=&rft.artnum=&rft.issn=0309-1317&rft.eissn=1468-2427&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1111/j.1468-2427.2005.00630.x&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft.eisbn=&rft_dat=<wj>10.1111/j.1468-2427.2005.00630.x</wj>&rft_id=info:oai/>]]></sear:openurlfulltext>\n
-        \         </sear:LINKS>\n        </sear:DOC>\n        <sear:DOC LOCAL=\"false\"
-        SEARCH_ENGINE_TYPE=\"Primo Central Search Engine\" SEARCH_ENGINE=\"PrimoCentralThirdNode\"
-        NO=\"9\" RANK=\"0.02218338\" ID=\"113602899\">\n          <prim:PrimoNMBib
-        xmlns=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\" xmlns:prim=\"http://www.exlibrisgroup.com/xsd/primo/primo_nm_bib\"
-        xmlns:sear=\"http://www.exlibrisgroup.com/xsd/jaguar/search\">\n            <prim:record>\n
-        \             <prim:control>\n                <prim:sourcerecordid>134458487</prim:sourcerecordid>\n
-        \               <prim:sourceid>gale_ofa</prim:sourceid>\n                <prim:recordid>TN_gale_ofa134458487</prim:recordid>\n
-        \               <prim:sourceformat>XML</prim:sourceformat>\n                <prim:sourcesystem>Other</prim:sourcesystem>\n
-        \             </prim:control>\n              <prim:display>\n                <prim:type>article</prim:type>\n
-        \               <prim:title><![CDATA[Transforming resistance, broadening our
-        boundaries: critical organizational communication meets <span class=\"searchword\">globalization</span>
-        <span class=\"searchword\">from</span> <span class=\"searchword\">below</span>.(Author
-        Abstract)]]></prim:title>\n                <prim:creator>Ganesh, Shiv ; Zoller,
-        Heather ; Cheney, George</prim:creator>\n                <prim:ispartof>Communication
-        Monographs, June, 2005, Vol.72(2), p.169(23)</prim:ispartof>\n                <prim:identifier>&lt;b>ISSN:
-        &lt;/b>0363-7751</prim:identifier>\n                <prim:subject>&lt;span
-        class=\"searchword\">Globalization&lt;/span> -- Social Aspects</prim:subject>\n
-        \               <prim:description>This essay addresses the need for organizational
-        communication scholarship to come to terms with the contested nature of &lt;span
-        class=\"searchword\">globalization&lt;/span> through analyses of collective
-        resistance. We argue that organizational communication has largely situated
-        the study of resistance at the level of the individual, and characterized
-        it as an element of micro-politics located within organizational boundaries.
-        Thus, resistance has been considered in localized, interpersonal terms, without
-        full appreciation of its political and ideological significance. This essay
-        builds a case for reconsidering resistance in order to study \"&lt;span class=\"searchword\">globalization&lt;/span>
-        &lt;span class=\"searchword\">from&lt;/span> &lt;span class=\"searchword\">below&lt;/span>\"
-        and highlights protest movements as exemplars of transformative resistance.
-        Finally, the essay advances a study of organizational communication with expanded
-        disciplinary engagement with respect to &lt;span class=\"searchword\">globalization&lt;/span>.
-        Keywords: Critical Studies; &lt;span class=\"searchword\">Globalization&lt;/span>;
-        Organizational Communication; Resistance; Social Movements</prim:description>\n
-        \               <prim:language>English</prim:language>\n                <prim:source>Cengage
-        Learning, Inc.</prim:source>\n                <prim:lds50>peer_reviewed</prim:lds50>\n
-        \               <prim:version>3</prim:version>\n                <prim:snippetfield>description</prim:snippetfield>\n
-        \               <prim:snippetfield>description</prim:snippetfield>\n                <prim:snippetfield>description</prim:snippetfield>\n
-        \               <prim:snippetfield>title</prim:snippetfield>\n                <prim:snippet>disciplinary
-        engagement with respect to &lt;span class=\"searchword\">globalization&lt;/span>.
-        Keywords: Critical Studies; &lt;span class=\"searchword\">Globalization&lt;/span>;
-        Organizational Communication; Resistance; Social Movements... This essay addresses
-        the need for organizational communication scholarship to come to terms with
-        the contested nature of &lt;span class=\"searchword\">globalization&lt;/span>
-        through analyses of collective resistance. We argue...  in order to study
-        \"&lt;span class=\"searchword\">globalization&lt;/span> &lt;span class=\"searchword\">from&lt;/span>
-        &lt;span class=\"searchword\">below&lt;/span>\" and highlights protest movements
-        as exemplars of transformative resistance. Finally, the essay advances a study
-        of organizational communication with expanded... Transforming resistance,
-        broadening our boundaries: critical organizational communication meets &lt;span
-        class=\"searchword\">globalization&lt;/span> &lt;span class=\"searchword\">from&lt;/span>
-        &lt;span class=\"searchword\">below&lt;/span>.(Author Abstract)</prim:snippet>\n
-        \             </prim:display>\n              <prim:links>\n                <prim:openurl>$$Topenurl_article</prim:openurl>\n
-        \               <prim:openurlfulltext>$$Topenurlfull_article</prim:openurlfulltext>\n
-        \             </prim:links>\n              <prim:search>\n                <prim:creatorcontrib>Ganesh,
-        Shiv</prim:creatorcontrib>\n                <prim:creatorcontrib>Ganesh</prim:creatorcontrib>\n
-        \               <prim:creatorcontrib>Zoller, Heather</prim:creatorcontrib>\n
-        \               <prim:creatorcontrib>Cheney, George</prim:creatorcontrib>\n
-        \               <prim:title><![CDATA[Transforming resistance, broadening our
-        boundaries: critical organizational communication meets <span class=\"searchword\">globalization</span>
-        <span class=\"searchword\">from</span> <span class=\"searchword\">below</span>.(Author
-        Abstract)]]></prim:title>\n                <prim:description>This essay addresses
-        the need for organizational communication scholarship to come to terms with
-        the contested nature of globalization through analyses of collective resistance.
-        We argue that organizational communication has largely situated the study
-        of resistance at the level of the individual, and characterized it as an element
-        of micro-politics located within organizational boundaries. Thus, resistance
-        has been considered in localized, interpersonal terms, without full appreciation
-        of its political and ideological significance. This essay builds a case for
-        reconsidering resistance in order to study \"globalization from below\" and
-        highlights protest movements as exemplars of transformative resistance. Finally,
-        the essay advances a study of organizational communication with expanded disciplinary
-        engagement with respect to globalization. Keywords: Critical Studies; Globalization;
-        Organizational Communication; Resistance; Social Movements</prim:description>\n
-        \               <prim:subject>Globalization--Social aspects</prim:subject>\n
-        \               <prim:general>English</prim:general>\n                <prim:general>Speech
-        Communication Association</prim:general>\n                <prim:general>Cengage
-        Learning, Inc.</prim:general>\n                <prim:sourceid>gale_ofa</prim:sourceid>\n
-        \               <prim:recordid>gale_ofa134458487</prim:recordid>\n                <prim:issn>0363-7751</prim:issn>\n
-        \               <prim:issn>03637751</prim:issn>\n                <prim:rsrctype>article</prim:rsrctype>\n
-        \               <prim:creationdate>2005</prim:creationdate>\n                <prim:recordtype>article</prim:recordtype>\n
-        \               <prim:addtitle>Communication Monographs</prim:addtitle>\n
-        \               <prim:searchscope>OneFile</prim:searchscope>\n                <prim:scope>OneFile</prim:scope>\n
-        \             </prim:search>\n              <prim:sort>\n                <prim:title>Transforming
-        resistance, broadening our boundaries: critical organizational communication
-        meets globalization from below.(Author Abstract)</prim:title>\n                <prim:author>Ganesh,
-        Shiv ; Zoller, Heather ; Cheney, George</prim:author>\n                <prim:creationdate>20050601</prim:creationdate>\n
-        \             </prim:sort>\n              <prim:facets>\n                <prim:language>eng</prim:language>\n
-        \               <prim:creationdate>2005</prim:creationdate>\n                <prim:topic>Globalization–Social
-        Aspects</prim:topic>\n                <prim:collection>OneFile (GALE)</prim:collection>\n
-        \               <prim:prefilter>articles</prim:prefilter>\n                <prim:rsrctype>articles</prim:rsrctype>\n
-        \               <prim:creatorcontrib>Ganesh, Shiv</prim:creatorcontrib>\n
-        \               <prim:creatorcontrib>Zoller, Heather</prim:creatorcontrib>\n
-        \               <prim:creatorcontrib>Cheney, George</prim:creatorcontrib>\n
-        \               <prim:jtitle>Communication Monographs</prim:jtitle>\n                <prim:toplevel>peer_reviewed</prim:toplevel>\n
-        \               <prim:frbrgroupid>4308494945219945461</prim:frbrgroupid>\n
-        \               <prim:frbrtype>5</prim:frbrtype>\n              </prim:facets>\n
-        \             <prim:frbr>\n                <prim:t>2</prim:t>\n                <prim:k1>2005</prim:k1>\n
-        \               <prim:k2>03637751</prim:k2>\n                <prim:k4>72</prim:k4>\n
-        \               <prim:k5>2</prim:k5>\n                <prim:k6>169</prim:k6>\n
-        \               <prim:k7>communication monographs</prim:k7>\n                <prim:k8>transforming
-        resistance broadening our boundaries critical organizational communication
-        meets globalization from below</prim:k8>\n                <prim:k9>transformingresistanbelow</prim:k9>\n
-        \               <prim:k12>transformingresistancebro</prim:k12>\n                <prim:k15>shivganesh</prim:k15>\n
-        \               <prim:k16>ganeshshiv</prim:k16>\n              </prim:frbr>\n
-        \             <prim:delivery>\n                <prim:delcategory>Remote Search
-        Resource</prim:delcategory>\n                <prim:fulltext>fulltext</prim:fulltext>\n
-        \             </prim:delivery>\n              <prim:ranking>\n                <prim:booster1>1</prim:booster1>\n
-        \               <prim:booster2>1</prim:booster2>\n                <prim:pcg_type>aggregator</prim:pcg_type>\n
-        \             </prim:ranking>\n              <prim:addata>\n                <prim:au>Ganesh,
-        Shiv</prim:au>\n                <prim:au>Zoller, Heather</prim:au>\n                <prim:au>Cheney,
-        George</prim:au>\n                <prim:atitle>Transforming resistance, broadening
-        our boundaries: critical organizational communication meets globalization
-        from below.(Author Abstract)</prim:atitle>\n                <prim:jtitle>Communication
-        Monographs</prim:jtitle>\n                <prim:date>20050601</prim:date>\n
-        \               <prim:risdate>20050601</prim:risdate>\n                <prim:volume>72</prim:volume>\n
-        \               <prim:issue>2</prim:issue>\n                <prim:spage>169</prim:spage>\n
-        \               <prim:issn>0363-7751</prim:issn>\n                <prim:genre>article</prim:genre>\n
-        \               <prim:ristype>JOUR</prim:ristype>\n                <prim:abstract>This
-        essay addresses the need for organizational communication scholarship to come
-        to terms with the contested nature of globalization through analyses of collective
-        resistance. We argue that organizational communication has largely situated
-        the study of resistance at the level of the individual, and characterized
-        it as an element of micro-politics located within organizational boundaries.
-        Thus, resistance has been considered in localized, interpersonal terms, without
-        full appreciation of its political and ideological significance. This essay
-        builds a case for reconsidering resistance in order to study \"globalization
-        from below\" and highlights protest movements as exemplars of transformative
-        resistance. Finally, the essay advances a study of organizational communication
-        with expanded disciplinary engagement with respect to globalization. Keywords:
-        Critical Studies; Globalization; Organizational Communication; Resistance;
-        Social Movements</prim:abstract>\n                <prim:pub>Speech Communication
-        Association</prim:pub>\n                <prim:lad01>gale_ofa</prim:lad01>\n
-        \             </prim:addata>\n            </prim:record>\n          </prim:PrimoNMBib>\n
-        \         <sear:GETIT GetIt2=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-08-20T15%3A54%3A45IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert%2C%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft_id=info:oai/>\"
-        GetIt1=\"http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2012-08-20T15%3A54%3A45IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert%2C%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft.eisbn=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft_id=info:oai/>\"
-        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-08-20T15%3A54%3A45IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Transforming%20resistance%2C%20broadening%20our%20boundaries:%20critical%20organizational%20communication%20meets%20globalization%20from%20below.(Author%20Abstract)&rft.jtitle=Communication%20Monographs&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Ganesh%2C%20Shiv&rft.aucorp=&rft.date=20050601&rft.volume=72&rft.issue=2&rft.part=&rft.quarter=&rft.ssn=&rft.spage=169&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0363-7751&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&rft.eisbn=&rft_dat=<gale_ofa>134458487</gale_ofa>&rft_id=info:oai/>]]></sear:openurl>\n
-        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx-demo.exlibrisgroup.com:3210/primo_demo?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2012-08-20T15%3A54%3A45IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-gale_ofa&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Transforming%20resistance%2C%20broadening%20our%20boundaries:%20critical%20organizational%20communication%20meets%20globalization%20from%20below.(Author%20Abstract)&rft.jtitle=Communication%20Monographs&rft.btitle=&rft.aulast=&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Ganesh%2C%20Shiv&rft.aucorp=&rft.date=20050601&rft.volume=72&rft.issue=2&rft.part=&rft.quarter=&rft.ssn=&rft.spage=169&rft.epage=&rft.pages=&rft.artnum=&rft.issn=0363-7751&rft.eissn=&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft.eisbn=&rft_dat=<gale_ofa>134458487</gale_ofa>&rft_id=info:oai/>]]></sear:openurlfulltext>\n
+        GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A16%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:GETIT GetIt2=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        GetIt1=\"http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi/enc:UTF-8&amp;ctx_tim=2013-05-06T22%3A20%3A50IST&amp;url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi/fmt:kev:mtx:ctx&amp;rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-sciversesciencedirect_elsevier&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:&amp;rft.genre=article&amp;rft.atitle=Multilingual%20organizations%20as%20‘linguascapes’:%20Negotiating%20the%20position%20of%20English%20through%20discursive%20practices&amp;rft.jtitle=Journal%20of%20World%20Business&amp;rft.btitle=&amp;rft.aulast=Steyaert&amp;rft.auinit=&amp;rft.auinit1=&amp;rft.auinitm=&amp;rft.ausuffix=&amp;rft.au=Steyaert,%20Chris&amp;rft.aucorp=&amp;rft.date=2011&amp;rft.volume=46&amp;rft.issue=3&amp;rft.part=&amp;rft.quarter=&amp;rft.ssn=&amp;rft.spage=270&amp;rft.epage=278&amp;rft.pages=270-278&amp;rft.artnum=&amp;rft.issn=1090-9516&amp;rft.eissn=&amp;rft.isbn=&amp;rft.sici=&amp;rft.coden=&amp;rft_id=info:doi/10.1016/j.jwb.2010.07.003&amp;rft.object_id=&amp;svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&amp;svc.fulltext=yes&amp;rft_dat=&lt;sciversesciencedirect_elsevier>S1090-9516(10)00042-8&lt;/sciversesciencedirect_elsevier>&amp;rft.eisbn=&amp;rft_id=info:oai/\"
+        deliveryCategory=\"Remote Search Resource\"/>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-wj&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20The%20Ranking%20of%20Global%20Immigrant%20Cities&rft.jtitle=International%20Journal%20of%20Urban%20and%20Regional%20Research&rft.btitle=&rft.aulast=BENTON‐SHORT&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Benton‐short,%20Lisa&rft.aucorp=&rft.date=200512&rft.volume=29&rft.issue=4&rft.part=&rft.quarter=&rft.ssn=&rft.spage=945&rft.epage=959&rft.pages=&rft.artnum=&rft.issn=0309-1317&rft.eissn=1468-2427&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1111/j.1468-2427.2005.00630.x&rft.object_id=&rft_dat=<wj>10.1111/j.1468-2427.2005.00630.x</wj>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A16%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-wj&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20The%20Ranking%20of%20Global%20Immigrant%20Cities&rft.jtitle=International%20Journal%20of%20Urban%20and%20Regional%20Research&rft.btitle=&rft.aulast=BENTON‐SHORT&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Benton‐short,%20Lisa&rft.aucorp=&rft.date=200512&rft.volume=29&rft.issue=4&rft.part=&rft.quarter=&rft.ssn=&rft.spage=945&rft.epage=959&rft.pages=&rft.artnum=&rft.issn=0309-1317&rft.eissn=1468-2427&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1111/j.1468-2427.2005.00630.x&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<wj>10.1111/j.1468-2427.2005.00630.x</wj>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
+        \         </sear:LINKS>\n          <sear:LINKS>\n            <sear:openurl><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-wj&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20The%20Ranking%20of%20Global%20Immigrant%20Cities&rft.jtitle=International%20Journal%20of%20Urban%20and%20Regional%20Research&rft.btitle=&rft.aulast=BENTON‐SHORT&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Benton‐short,%20Lisa&rft.aucorp=&rft.date=200512&rft.volume=29&rft.issue=4&rft.part=&rft.quarter=&rft.ssn=&rft.spage=945&rft.epage=959&rft.pages=&rft.artnum=&rft.issn=0309-1317&rft.eissn=1468-2427&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1111/j.1468-2427.2005.00630.x&rft.object_id=&rft_dat=<wj>10.1111/j.1468-2427.2005.00630.x</wj>&rft.eisbn=&rft_id=info:oai/]]></sear:openurl>\n
+        \           <sear:thumbnail/>\n            <sear:openurlfulltext><![CDATA[http://sfx.example.org/sfx?ctx_ver=Z39.88-2004&ctx_enc=info:ofi/enc:UTF-8&ctx_tim=2013-05-06T22%3A20%3A50IST&url_ver=Z39.88-2004&url_ctx_fmt=infofi/fmt:kev:mtx:ctx&rfr_id=info:sid/primo.exlibrisgroup.com:primo3-Article-wj&rft_val_fmt=info:ofi/fmt:kev:mtx:&rft.genre=article&rft.atitle=Globalization%20from%20Below:%20The%20Ranking%20of%20Global%20Immigrant%20Cities&rft.jtitle=International%20Journal%20of%20Urban%20and%20Regional%20Research&rft.btitle=&rft.aulast=BENTON‐SHORT&rft.auinit=&rft.auinit1=&rft.auinitm=&rft.ausuffix=&rft.au=Benton‐short,%20Lisa&rft.aucorp=&rft.date=200512&rft.volume=29&rft.issue=4&rft.part=&rft.quarter=&rft.ssn=&rft.spage=945&rft.epage=959&rft.pages=&rft.artnum=&rft.issn=0309-1317&rft.eissn=1468-2427&rft.isbn=&rft.sici=&rft.coden=&rft_id=info:doi/10.1111/j.1468-2427.2005.00630.x&rft.object_id=&svc_val_fmt=info:ofi/fmt:kev:mtx:sch_svc&svc.fulltext=yes&rft_dat=<wj>10.1111/j.1468-2427.2005.00630.x</wj>&rft.eisbn=&rft_id=info:oai/]]></sear:openurlfulltext>\n
         \         </sear:LINKS>\n        </sear:DOC>\n      </sear:DOCSET>\n    </sear:RESULT>\n
-        \   <sear:searchToken>0</sear:searchToken>\n  </sear:JAGROOT>\n</sear:SEGMENTS>\n"
+        \ </sear:JAGROOT>\n</sear:SEGMENTS>\n"
     http_version: 
-  recorded_at: Mon, 20 Aug 2012 20:54:45 GMT
-recorded_with: VCR 2.2.4
+  recorded_at: Tue, 07 May 2013 03:20:53 GMT
+recorded_with: VCR 2.4.0


### PR DESCRIPTION
Our primo server was failing due to the indx not being passed in, so
now regardless of if args[:start] is passed in, the indx is added to
the Primo URL.

The Primo vcr cassettes were regenerated with the new code as the URLs
changed (i.e. &indx=1 is now included). I did have to modify the smoke
test as a few fields weren't in the newly recorded results so the test
was failing.
