### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ may be required for certain engines.
 `results` are a [BentoSearch::Results](./app/models/bento_search/results.rb) object, which acts like an array of
 [BentoSearch::ResultItem](./app/models/bento_search/result_item.rb) objects, along with some meta-information about the
 search itself (pagination keys, etc).  BentoSearch::Results and Item fields
-are standardized accross engines. BentoSearch::Items provide semantic
+are standardized across engines. BentoSearch::Items provide semantic
 values (title, author, etc.), as available from the particular engine.
 
 To see which engines come bundled with BentoSearch, and any special


### PR DESCRIPTION
@jrochkind, I've corrected a typographical error in the documentation of the [bento_search](https://github.com/jrochkind/bento_search) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.