### PR TITLE
BentoSearch::SearchEngine engine_id and display_configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,9 @@
     * If you previously turned off Rails dev-mode class reloading, it should
       work again in Rails5 with the ConcurrentSearcher.
 
+* BentoSearch::SearchEngine has `engine_id` and `display_configuration` cover
+  methods added, for consistency with BentoSearch::Results
+
 ## 1.6
 
 * Test under Rails5

--- a/app/models/bento_search/search_engine.rb
+++ b/app/models/bento_search/search_engine.rb
@@ -429,6 +429,16 @@ module BentoSearch
       [:query, :search_field, :semantic_search_field, :sort, :page, :start, :per_page]
     end
 
+    # Cover method for consistent api with Results
+    def display_configuration
+      configuration.for_display
+    end
+
+    # Cover method for consistent api with Results
+    def engine_id
+      configuration.id
+    end
+
 
     protected
 

--- a/test/search_engines/search_engine_base_test.rb
+++ b/test/search_engines/search_engine_base_test.rb
@@ -288,5 +288,16 @@ class ParseSearchArgumentsTest < ActiveSupport::TestCase
     assert_equal "I am a horrible engine", results.error[:exception].message, "results.error has right exception"
   end
 
+  def test_cover_consistency_api
+    d = Dummy.new()
+    assert_nil d.engine_id
+    assert_equal({}, d.display_configuration)
+
+    d = Dummy.new(id: 'test', for_display: { testkey: 'test' })
+    assert_equal 'test', d.engine_id
+    assert_equal({ testkey: 'test' }, d.display_configuration)
+
+  end
+
 end
 


### PR DESCRIPTION
cover methods added, for consistency with BentoSearch::Results