### PR TITLE
support string type for setting of "auth" arg

### DIFF
--- a/app/search_engines/bento_search/summon_engine.rb
+++ b/app/search_engines/bento_search/summon_engine.rb
@@ -317,7 +317,7 @@ class BentoSearch::SummonEngine
       query_params['s.sort'] =  literal
     end
 
-    if args[:auth] == true
+    if [true, "true"].include? args[:auth]
       query_params['s.role'] = "authenticated"
     end
 


### PR DESCRIPTION
The existing code assumes that this parameter should never be set by the client as a URL query parameter. Given this assumption, it would be reasonable to assume that the value (set server-side by the application) will be a proper boolean. 

This proposed change implies a question about the assumption that the `auth` parameter should be considered authentication in the *security* sense of the word; should it instead simply be seen as a *convenience* parameter to avoid presenting users with results that they will not be authorized to access? To put it another way: are we intersted in controlling access to the search results per se, or only to the content that they represent? 

Without modification of the `public_settable_search_args`, the proposed change does nothing except loosen the syntax for setting the auth param. But in the absence of a desire to support setting this param on the client side, this loosening could be undesirable. If in *all* circumstances it would be desirable to prevent this parameter from being set on the client side, then this PR should probably just be closed. 

Thanks for considering!