### PR TITLE
language_list 1.2.0 has backwards incompat changes:

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 1.7.1
+
+* Workaround backwards-incompat changes in language_list 1.2.0 (https://github.com/scsmith/language_list/issues/19)
+
 ## 1.7
 
 * search engines now have a `configuration.default_per_page`

--- a/app/models/bento_search/result_item.rb
+++ b/app/models/bento_search/result_item.rb
@@ -157,7 +157,7 @@ module BentoSearch
     attr_writer :language_str
     def language_str
       (@language_str ||= nil) || language_code.try do |code|
-        LanguageList::LanguageInfo.find(code).try do |lang_obj|
+        LanguageList::LanguageInfo.find(code.dup).try do |lang_obj|
           lang_obj.name
         end
       end
@@ -167,7 +167,10 @@ module BentoSearch
     # if available, otherwise from direct language_str if available and
     # possible.
     def language_obj
-      @language_obj ||= LanguageList::LanguageInfo.find( self.language_code || self.language_str )
+      @language_obj ||= begin
+        lookup = self.language_code || self.language_str
+        LanguageList::LanguageInfo.find( lookup.dup ) if lookup
+      end
     end
 
     # Two letter ISO language code, or nil


### PR DESCRIPTION
* mutates argument passed in to LanguageList::LanguageInfo.find
* raises on nil argument passed in LanguageList::LanguageInfo.find

Workaround so these changes are invisible to consumer of bento_search