### PR TITLE
Avoid deprecation warnings in test

### DIFF
--- a/app/controllers/bento_search/search_controller.rb
+++ b/app/controllers/bento_search/search_controller.rb
@@ -19,10 +19,10 @@ module BentoSearch
   # in their config will be served by this controller.
   #
   # If you need routable results on an engine which ALSO needs to
-  # be protected by auth, you can add your own Rails before_filter
+  # be protected by auth, you can add your own Rails before_action
   # to provide auth. Say, in an initializer in your app:
   #
-  #     SearchController.before_filter do |controller|
+  #     SearchController.before_action do |controller|
   #       unless controller.current_user
   #          raise BentoSearch::SearchController::AccessDenied
   #       end

--- a/test/decorator/standard_decorator_test.rb
+++ b/test/decorator/standard_decorator_test.rb
@@ -4,74 +4,74 @@ require 'test_helper'
 
 class StandardDecoratorTest < ActionView::TestCase
   include BentoSearch
-  
-  def decorator(hash = {})    
+
+  def decorator(hash = {})
     StandardDecorator.new(
       ResultItem.new(hash), view
     )
   end
-  
-  
+
+
   test "author with first and last" do
     author = Author.new(:last => "Smith", :first => "John")
-    
+
     str = decorator.author_display(author)
-    
-    assert_equal "Smith, J", str    
+
+    assert_equal "Smith, J", str
   end
-  
+
   test "author with display form and just last" do
     author = Author.new(:last => "Smith", :display => "Display Form")
-    
+
     str = decorator.author_display(author)
-    
+
     assert_equal "Display Form", str
   end
-  
+
   test "Author with just last" do
     author = Author.new(:last => "Johnson")
-    
+
     str = decorator.author_display(author)
-    
+
     assert_equal "Johnson", str
-    
+
   end
-  
+
   test "Missing title" do
     assert_equal I18n.translate("bento_search.missing_title"), decorator.complete_title
   end
-  
+
   test "language label nil if default" do
     I18n.with_locale(:'en-GB') do
-      item = decorator(:language_code => 'en')      
+      item = decorator(:language_code => 'en')
       assert_nil item.display_language
-      
+
       item = decorator(:language_code => 'es')
-      assert_equal "Spanish", item.display_language      
+      assert_equal "Spanish", item.display_language
     end
   end
 
   test "display_language works with just langauge_str" do
-     item = decorator(:language_str => 'German')      
+     item = decorator(:language_str => 'German')
      assert_equal "German", item.display_language
   end
-  
+
   test "display_format with nil format" do
     item = decorator(:format => nil, :format_str => nil)
-    
+
     display_format = item.display_format
-    
-    assert_nil display_format  
+
+    assert_nil display_format
   end
-  
+
   test "display_date" do
-    item = decorator(:year => 1900)    
+    item = decorator(:year => 1900)
     assert_equal "1900", item.display_date
-    
+
     d = Date.new(2010, 5, 5)
     item = decorator(:publication_date => d)
     assert_equal I18n.l(d, :format => "%d %b %Y"), item.display_date
-    
+
     # if volume and issue, only prints out year
     item = decorator(:publication_date => d, :volume => "101", :issue => "2")
     assert_equal I18n.l(d, :format => "%Y"), item.display_date
@@ -112,7 +112,7 @@ class StandardDecoratorTest < ActionView::TestCase
     assert_equal "snippet", item.render_summary, "use snippet if that's all that's there, even when configured for abstract"
 
     item = decorator()
-    assert_equal nil, item.render_summary, "Okay with no snippet or abstract"
+    assert_nil item.render_summary, "Okay with no snippet or abstract"
   end
-  
+
 end

--- a/test/dummy/config/environments/production.rb
+++ b/test/dummy/config/environments/production.rb
@@ -9,7 +9,11 @@ Dummy::Application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_files = false
+  if Rails::VERSION::MAJOR < 5
+    config.serve_static_files = false
+  else
+    config.public_file_server.enabled = false
+  end
 
   # Compress JavaScripts and CSS
   config.assets.compress = true

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -8,11 +8,16 @@ Dummy::Application.configure do
   config.cache_classes = true
 
   # Configure static asset server for tests with Cache-Control for performance
-  config.serve_static_files = true
-  config.static_cache_control = "public, max-age=3600"
+  if Rails::VERSION::MAJOR < 5
+    config.serve_static_files = true
+    config.static_cache_control = "public, max-age=3600"
+  else
+    config.public_file_server.enabled = true
+    config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
+  end
 
   config.eager_load = false
-  
+
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false

--- a/test/functional/bento_search/search_controller_test.rb
+++ b/test/functional/bento_search/search_controller_test.rb
@@ -114,7 +114,11 @@ module BentoSearch
       # SUPER HACKY, but I dunno what else to do.
 
       class CustomSearchController < BentoSearch::SearchController
-        before_filter :deny_everyone
+        if respond_to?(:before_action)
+          before_action :deny_everyone
+        else
+          before_filter :deny_everyone
+        end
 
         def deny_everyone
           raise BentoSearch::SearchController::AccessDenied


### PR DESCRIPTION
ESpecially Rails5 ones, to prepare for 5.1. 

All changes are just to test code, no change to non-test code
here.