### PR TITLE
Protocol specific args engine extension

### DIFF
--- a/app/controllers/bento_search/search_controller.rb
+++ b/app/controllers/bento_search/search_controller.rb
@@ -51,7 +51,9 @@ module BentoSearch
         raise AccessDenied.new("engine needs to be registered with :allow_routable_results => true")
       end
 
-      @results         = engine.search safe_search_args(engine, params)
+      params = safe_search_args(engine, params)
+      params = protocol_specific_args(engine, params)
+      @results         = engine.search params
       # template name of a partial with 'yield' to use to wrap the results
       @partial_wrapper = @results.display_configuration.lookup!("ajax.wrapper_template")
 
@@ -63,6 +65,11 @@ module BentoSearch
 
 
     protected
+
+    def protocol_specific_args(engine, params)
+      protocol_specific_state = { :http_request => request }
+      engine.add_protocol_specific_args(params, protocol_specific_state)
+    end
 
     def safe_search_args(engine, params)
       all_hash = params.respond_to?(:to_unsafe_hash) ? params.to_unsafe_hash : params.to_hash

--- a/app/controllers/bento_search/search_controller.rb
+++ b/app/controllers/bento_search/search_controller.rb
@@ -50,10 +50,9 @@ module BentoSearch
       unless engine.configuration.allow_routable_results == true
         raise AccessDenied.new("engine needs to be registered with :allow_routable_results => true")
       end
-
-      params = safe_search_args(engine, params)
-      params = protocol_specific_args(engine, params)
-      @results         = engine.search params
+      all_hash = safe_search_args(engine, params)
+      all_hash = protocol_specific_args(engine, all_hash)
+      @results         = engine.search all_hash
       # template name of a partial with 'yield' to use to wrap the results
       @partial_wrapper = @results.display_configuration.lookup!("ajax.wrapper_template")
 
@@ -66,9 +65,9 @@ module BentoSearch
 
     protected
 
-    def protocol_specific_args(engine, params)
+    def protocol_specific_args(engine, all_hash)
       protocol_specific_state = { :http_request => request }
-      engine.add_protocol_specific_args(params, protocol_specific_state)
+      engine.add_protocol_specific_args(all_hash, protocol_specific_state)
     end
 
     def safe_search_args(engine, params)

--- a/app/models/bento_search/search_engine.rb
+++ b/app/models/bento_search/search_engine.rb
@@ -440,6 +440,12 @@ module BentoSearch
       [:query, :search_field, :semantic_search_field, :sort, :page, :start, :per_page]
     end
 
+    # Hook to allow engines to augment with certain params (e.g., auth)
+    # that are most naturally accomplished with protocol-awareness
+    def add_protocol_specific_args(params, protocol_specific_state)
+      params # default stub implementation returns params unmodified
+    end
+
     # Cover method for consistent api with Results
     def display_configuration
       configuration.for_display

--- a/app/models/bento_search/search_engine.rb
+++ b/app/models/bento_search/search_engine.rb
@@ -442,8 +442,8 @@ module BentoSearch
 
     # Hook to allow engines to augment with certain params (e.g., auth)
     # that are most naturally accomplished with protocol-awareness
-    def add_protocol_specific_args(params, protocol_specific_state)
-      params # default stub implementation returns params unmodified
+    def add_protocol_specific_args(all_hash, protocol_specific_state)
+      all_hash # default stub implementation returns params unmodified
     end
 
     # Cover method for consistent api with Results


### PR DESCRIPTION
To accompany #30, we wanted to finer-grained determination of how to set the auth param. Since different engines might have different concepts of "auth", and how to make that determination, it seems reasonable for that determination to made at the level of a specific engine. Since engines (as opposed to search controllers) are commonly subclassed for an individual deployment anyway, that makes overriding at this level all the more attractive. 

The solution proposed in this PR should be extensible, and not specific to auth, but the auth use case is a good one, because many finer-grained auth schemes rely on protocol- or environment-specific factors (such as http headers or server side user session state). 

The goal is to maintain the protocol-agnostic nature of the search engines, but allow individual engines to be overridden with awareness of protocol-specific features. The controller implementation included in the PR sends the original http request, which may be intercepted by a search_engine that implements, e.g.

```ruby
def add_protocol_specific_args(params, protocol_specific_state)
  request = protocol_specific_state[:http_request]
  auth = request.headers['authorization']
  params[:auth] = validate_auth?(auth)
  return params
end
```
... but in the future the controller could be extended (in the `protocol_specific_args` method) to pass other protocol- or session-specific information which could then be handled or ignored as individual search engines see fit. 

Suggestions welcome, and thank you!