### PR TITLE
Keep hierarchical headings structure by changing h4 to h3

### DIFF
--- a/app/views/bento_search/_item_title.html.erb
+++ b/app/views/bento_search/_item_title.html.erb
@@ -17,7 +17,7 @@
   # marker will be output after title, in class .bento_available_online
   #
   # %>
-  <h4 class="bento_item_title">
+  <h3 class="bento_item_title">
     <% if local_assigns[:index] %>
       <% id_attr = item.html_id(local_assigns[:id_prefix], index) %>
       <%= content_tag("span", :class => "bento_index", :id => (id_attr if id_attr)) do %>
@@ -39,6 +39,4 @@
     <% if item.display_configuration.try{|h| h[:indicate_fulltext]} && item.link_is_fulltext? %>
       <small class="bento_available_online">Online</small>
     <% end %>
-  </h4>
-
-
+  </h3>


### PR DESCRIPTION
When conducting an accessibility review of our site recently, it came up as an issue that we were not keeping the hierarchical structure of headings and the recommendation was made to change the h4 heading in bento_search/_item_title.html.erb to an h3.  We have made this change locally, but thought we would also offer it here in case others are in need of this change as well.