### PR TITLE
Get atom XSD validation test working again

### DIFF
--- a/test/support/atom.xsd.xml
+++ b/test/support/atom.xsd.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<xs:schema targetNamespace="http://www.w3.org/2005/Atom" elementFormDefault="qualified" 
+<xs:schema targetNamespace="http://www.w3.org/2005/Atom" elementFormDefault="qualified"
 	attributeFormDefault="unqualified"
 	xmlns:atom="http://www.w3.org/2005/Atom" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 	<xs:annotation>
@@ -8,7 +8,7 @@
 				found here http://www.atomenabled.org/developers/syndication/atom-format-spec.php.
 			</xs:documentation>
 	</xs:annotation>
-	<xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd" />
+	<xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="./xml.xsd" />
 	<xs:annotation>
 		<xs:documentation>
 			An Atom document may have two root elements, feed and entry, as defined in section 2.

--- a/test/support/xml.xsd
+++ b/test/support/xml.xsd
@@ -1,0 +1,117 @@
+<?xml version='1.0'?>
+<!DOCTYPE xs:schema PUBLIC "-//W3C//DTD XMLSCHEMA 200102//EN" "XMLSchema.dtd" >
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:xs="http://www.w3.org/2001/XMLSchema" xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   See http://www.w3.org/XML/1998/namespace.html and
+   http://www.w3.org/TR/REC-xml for information about this namespace.
+
+    This schema document describes the XML namespace, in a form
+    suitable for import by other schema documents.  
+
+    Note that local names in this namespace are intended to be defined
+    only by the World Wide Web Consortium or its subgroups.  The
+    following names are currently defined in this namespace and should
+    not be used with conflicting semantics by any Working Group,
+    specification, or document instance:
+
+    base (as an attribute name): denotes an attribute whose value
+         provides a URI to be used as the base for interpreting any
+         relative URIs in the scope of the element on which it
+         appears; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML Base specification.
+
+    lang (as an attribute name): denotes an attribute whose value
+         is a language code for the natural language of the content of
+         any element; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML specification.
+  
+    space (as an attribute name): denotes an attribute whose
+         value is a keyword indicating what whitespace processing
+         discipline is intended for the content of the element; its
+         value is inherited.  This name is reserved by virtue of its
+         definition in the XML specification.
+
+    Father (in any context at all): denotes Jon Bosak, the chair of 
+         the original XML Working Group.  This name is reserved by 
+         the following decision of the W3C XML Plenary and 
+         XML Coordination groups:
+
+             In appreciation for his vision, leadership and dedication
+             the W3C XML Plenary on this 10th day of February, 2000
+             reserves for Jon Bosak in perpetuity the XML name
+             xml:Father
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>This schema defines attributes and an attribute group
+        suitable for use by
+        schemas wishing to allow xml:base, xml:lang or xml:space attributes
+        on elements they define.
+
+        To enable this, such a schema must import this schema
+        for the XML namespace, e.g. as follows:
+        &lt;schema . . .>
+         . . .
+         &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                    schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
+
+        Subsequently, qualified reference to any of the attributes
+        or the group defined below will have the desired effect, e.g.
+
+        &lt;type . . .>
+         . . .
+         &lt;attributeGroup ref="xml:specialAttrs"/>
+ 
+         will define a type which will schema-validate an instance
+         element with any of those attributes</xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>In keeping with the XML Schema WG's standard versioning
+   policy, this schema document will persist at
+   http://www.w3.org/2001/03/xml.xsd.
+   At the date of issue it can also be found at
+   http://www.w3.org/2001/xml.xsd.
+   The schema document at that URI may however change in the future,
+   in order to remain compatible with the latest version of XML Schema
+   itself.  In other words, if the XML Schema namespace changes, the version
+   of this document at
+   http://www.w3.org/2001/xml.xsd will change
+   accordingly; the version at
+   http://www.w3.org/2001/03/xml.xsd will not change.
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang" type="xs:language">
+  <xs:annotation>
+   <xs:documentation>In due course, we should install the relevant ISO 2- and 3-letter
+         codes as the enumerated possible values . . .</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attribute name="space" default="preserve">
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="base" type="xs:anyURI">
+  <xs:annotation>
+   <xs:documentation>See http://www.w3.org/TR/xmlbase/ for
+                     information about this attribute.</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+ </xs:attributeGroup>
+
+</xs:schema>

--- a/test/view/atom_results_test.rb
+++ b/test/view/atom_results_test.rb
@@ -4,7 +4,7 @@ require 'nokogiri'
 
 class AtomResultsTest < ActionView::TestCase
   include ActionView::Helpers::UrlHelper
-  
+
   @@namespaces = {
     "atom"        => "http://www.w3.org/2005/Atom",
     "opensearch"  => "http://a9.com/-/spec/opensearch/1.1/",
@@ -12,7 +12,7 @@ class AtomResultsTest < ActionView::TestCase
     "dcterms"     => "http://purl.org/dc/terms/",
     "bibo"        => "http://purl.org/ontology/bibo/"
   }
-  
+
   # Instead of using assert_select, we do it ourselves with nokogiri
   # for better namespace control.
   #
@@ -21,26 +21,26 @@ class AtomResultsTest < ActionView::TestCase
   #   assert matched_node.first["attribute"] == "foo"
   # end
   def assert_node(xml, xpath, options = {})
-    result = xml.xpath(xpath, @@namespaces)         
-    
+    result = xml.xpath(xpath, @@namespaces)
+
     assert result.length > 0, "Expected xpath '#{xpath}' to match in #{xml.to_s[0..200]}..."
-    
+
     if options[:text]
       assert_equal options[:text], result.text.strip, "Expected #{options[:text]} as content of #{result.to_s[0..200]}"
     end
-    
+
     yield result if block_given?
   end
-  
+
   def setup
     @total_items = 1000
     @start       = 6
     @per_page    = 15
-    
-    
-    @engine = BentoSearch::MockEngine.new(:total_items => @total_items)    
+
+
+    @engine = BentoSearch::MockEngine.new(:total_items => @total_items)
     @results = @engine.search("some query", :start => @start, :per_page => @per_page)
-    
+
     # but fill the first result elements with some non-blank data to test
     @article = BentoSearch::ResultItem.new(
       :title      => "An Article", #
@@ -66,7 +66,7 @@ class AtomResultsTest < ActionView::TestCase
         BentoSearch::Link.new(:url => "http://example.org/bare_link"),
         BentoSearch::Link.new(
           :url    => "http://example.org/label_and_type",
-          :label  => "A link somewhere",      
+          :label  => "A link somewhere",
           :type   => "application/pdf"
         ),
         BentoSearch::Link.new(
@@ -93,189 +93,189 @@ class AtomResultsTest < ActionView::TestCase
       :oclcnum   => "12124345",
       :year      => "2004"
     )
-    
-    
-     
+
+
+
     @results[0] = @article
     @results[1] = @article_with_html_abstract
     @results[3] = @article_with_full_date
-    @results[4] = @book    
+    @results[4] = @book
   end
-  
+
   def test_smoke_atom_validate
     # Validate under Atom schema. Should we validate under prism and dc schemas
     # too? Not sure if it makes sense, or if there's even a relevant schema
-    # for how we're using em. So of just basic 'smoke' value. 
+    # for how we're using em. So of just basic 'smoke' value.
     render :template => "bento_search/atom_results", :locals => {:atom_results => @results}
     xml_response = Nokogiri::XML( rendered ) { |config| config.strict }
-    
+
     atom_xsd_filepath = File.expand_path("../../support/atom.xsd.xml",  __FILE__)
-    schema_xml        = Nokogiri::XML(File.read(atom_xsd_filepath))
+    schema_xml        = Nokogiri::XML(File.open(atom_xsd_filepath))
     # modify to add processContents lax so it'll let us include elements from
-    # external namespaces. 
+    # external namespaces.
     schema_xml.xpath("//xs:any[@namespace='##other']", {"xs" => "http://www.w3.org/2001/XMLSchema"}).each do |node|
       node["processContents"] = "lax"
-    end    
-    
+    end
+
     schema = Nokogiri::XML::Schema.from_document( schema_xml )
-        
-    assert_empty schema.validate(xml_response), "Validates with atom XSD schema"       
+
+    assert_empty schema.validate(xml_response), "Validates with atom XSD schema"
   end
-  
-  
+
+
   def test_feed_metadata
-    render :template => "bento_search/atom_results", :locals => {:atom_results => @results}    
-    xml_response = Nokogiri::XML( rendered ) 
-    
-    assert_node(xml_response, "atom:feed") do |feed|            
+    render :template => "bento_search/atom_results", :locals => {:atom_results => @results}
+    xml_response = Nokogiri::XML( rendered )
+
+    assert_node(xml_response, "atom:feed") do |feed|
       assert_node(feed, "atom:title")
       assert_node(feed, "atom:author")
       assert_node(feed, "atom:updated")
-      
+
       assert_node(feed, "opensearch:totalResults", :text => @total_items.to_s)
       assert_node(feed, "opensearch:startIndex",   :text => @start.to_s)
       assert_node(feed, "opensearch:itemsPerPage", :text => @per_page.to_s)
     end
-    
+
   end
-  
+
   def test_article_entry_example
-    render :template => "bento_search/atom_results", :locals => {:atom_results => @results}    
-    xml_response = Nokogiri::XML( rendered ) 
-    
+    render :template => "bento_search/atom_results", :locals => {:atom_results => @results}
+    xml_response = Nokogiri::XML( rendered )
+
     assert_node(xml_response, "./atom:feed/atom:entry[1]") do |article|
-      assert_node(article, "atom:title", :text => @article.title)  
+      assert_node(article, "atom:title", :text => @article.title)
       assert_node(article, "prism:coverDate", :text => @article.year)
-      
+
       assert_node(article, "prism:issn", :text => @article.issn)
       assert_node(article, "prism:doi", :text => @article.doi)
-      
+
       assert_node(article, "prism:volume", :text => @article.volume)
       assert_node(article, "prism:number",  :text => @article.issue)
-      
+
       assert_node(article, "prism:startingPage", :text => @article.start_page)
       assert_node(article, "prism:endingPage",   :text => @article.end_page)
-      
+
       assert_node(article, "prism:publicationName", :text => @article.source_title)
-      
+
       abstract = article.at_xpath("atom:summary", @@namespaces)
       assert_present abstract, "Has an abstract"
       assert_equal "text", abstract["type"], "Abstract type text"
       assert_equal @article.abstract, abstract.text
-      
+
       assert_node(article, "dcterms:language[@vocabulary='http://dbpedia.org/resource/ISO_639-1']", :text => @article.language_iso_639_1)
       assert_node(article, "dcterms:language[@vocabulary='http://dbpedia.org/resource/ISO_639-3']", :text => @article.language_iso_639_3)
-      assert_node(article, "dcterms:language[not(@vocabulary)]", :text => @article.language_str)   
-      
+      assert_node(article, "dcterms:language[not(@vocabulary)]", :text => @article.language_str)
+
       assert_node(article, "dcterms:type[not(@vocabulary)]", :text => @article.format_str)
-            
+
       assert_node(article, "dcterms:type[@vocabulary='http://schema.org/']", :text => @article.schema_org_type_url)
       assert_node(article, "dcterms:type[@vocabulary='http://purl.org/NET/bento_search/ontology']", :text => @article.format)
-      
-      # Just make sure right number of author elements, with right structure. 
+
+      # Just make sure right number of author elements, with right structure.
       assert_node(article, "atom:author/atom:name") do |authors|
         assert_equal @article.authors.length, authors.length, "right number of author elements"
       end
-      
+
       # Links. Main link is just rel=alternate
-      assert_node(article, 
+      assert_node(article,
         "atom:link[@rel='alternate'][@href='#{@article.link}']")
-      
+
       # other links also there, default rel=related
-      assert_node(article, 
+      assert_node(article,
         "atom:link[@rel='related'][@type='application/pdf'][@title='A link somewhere'][@href='http://example.org/label_and_type']")
       assert_node(article,
-        "atom:link[@rel='something'][@href='http://example.org/rel']")                  
-    end    
-            
+        "atom:link[@rel='something'][@href='http://example.org/rel']")
+    end
+
   end
-  
-  
+
+
   def test_with_unique_id
-    @results  = @engine.search("find")    
+    @results  = @engine.search("find")
     @results[0] = BentoSearch::ResultItem.new(
-      :title => "Something",      
+      :title => "Something",
       :unique_id => "a000:/01",
       :engine_id => "some_engine"
     )
-    
-    render :template => "bento_search/atom_results", :locals => {:atom_results => @results}    
+
+    render :template => "bento_search/atom_results", :locals => {:atom_results => @results}
     xml_response = Nokogiri::XML( rendered )
-    
+
     with_unique_id = xml_response.xpath("./atom:feed/atom:entry", @@namespaces)[0]
-    
+
     assert_node(with_unique_id, "atom:id") do |id|
       # based off of engine_id and unique_id
       assert_includes id.text, "some_engine"
       assert_includes id.text, "a000%3A%2F01"
-    end      
+    end
   end
-  
+
   def test_with_html_abstract
-    render :template => "bento_search/atom_results", :locals => {:atom_results => @results}    
+    render :template => "bento_search/atom_results", :locals => {:atom_results => @results}
     xml_response = Nokogiri::XML( rendered )
-    
+
     with_html_abstract = xml_response.xpath("./atom:feed/atom:entry", @@namespaces)[1]
-    
-    assert_node(with_html_abstract, "atom:summary[@type='html']", :text => @article_with_html_abstract.abstract.to_s)      
+
+    assert_node(with_html_abstract, "atom:summary[@type='html']", :text => @article_with_html_abstract.abstract.to_s)
   end
-  
+
   def test_book
-    render :template => "bento_search/atom_results", :locals => {:atom_results => @results}    
+    render :template => "bento_search/atom_results", :locals => {:atom_results => @results}
     xml_response = Nokogiri::XML( rendered )
-        
+
     book = xml_response.xpath("./atom:feed/atom:entry", @@namespaces)[4]
-    
+
     assert_node(book, "dcterms:type[@vocabulary='http://purl.org/NET/bento_search/ontology']", :text => "Book")
     assert_node(book, "dcterms:type[@vocabulary='http://schema.org/']", :text => "http://schema.org/Book")
-    
+
     assert_node(book, "dcterms:publisher", :text => @book.publisher)
-    
+
     assert_node(book, "prism:isbn", :text => @book.isbn)
-    
+
     assert_node(book, "bibo:oclcnum", :text => @book.oclcnum)
   end
-  
+
   def test_with_full_date
-    render :template => "bento_search/atom_results", :locals => {:atom_results => @results}    
+    render :template => "bento_search/atom_results", :locals => {:atom_results => @results}
     xml_response = Nokogiri::XML( rendered )
-    
+
     with_full_date = xml_response.at_xpath("./atom:feed/atom:entry[4]", @@namespaces)
-    
-    assert_node(with_full_date, "prism:coverDate", :text => "2011-05-06")    
+
+    assert_node(with_full_date, "prism:coverDate", :text => "2011-05-06")
   end
 
   def test_nil_results
     # should render a more or less empty atom response for
     # nil results, convenient to not raise on nil
-    render :template => "bento_search/atom_results", :locals => {:atom_results => nil}   
+    render :template => "bento_search/atom_results", :locals => {:atom_results => nil}
   end
-  
+
   def test_locals_for_feed_name_and_author
-    render( :template => "bento_search/atom_results", 
-      :locals => {:atom_results => @results, 
+    render( :template => "bento_search/atom_results",
+      :locals => {:atom_results => @results,
                   :feed_name => "My Feed",
                   :feed_author_name => "ACME Seed And Feed Products"}
     )
-                  
+
     xml_response = Nokogiri::XML( rendered )
-    
+
     assert_node(xml_response, "./atom:feed/atom:title", :text => "My Feed")
     assert_node(xml_response, "./atom:feed/atom:author/atom:name", :text => "ACME Seed And Feed Products")
   end
-  
+
   def test_html_in_title_stripped
     results = BentoSearch::Results.new
     results << BentoSearch::ResultItem.new(
       :title => "html <b>title</b>".html_safe
     )
-    
+
     render(:template => "bento_search/atom_results", :locals => {:atom_results => results})
     xml_response = Nokogiri::XML( rendered )
-        
+
     assert_node(xml_response, "./atom:feed/atom:entry[1]/atom:title", :text => "html title")
-    
+
   end
-  
-  
+
+
 end


### PR DESCRIPTION
For reasons unclear, it stopped working to load the atom xsd into nokogiri. It tried to import a subsidiary XSD from http://www.w3.org/2001/03/xml.xsd -- this started silently failing, which then made load of the schema file itself fail. I think maybe because that started redirecting to an `https` URL, and libxml can't import that for us?

Loading that external XSD on every test run is maybe rude anyway.  Best practices for this kind of stuff are unclear, with the general decline of this kind of semantic XML stuff.

To make it work again, I made a local copy of the xml.xsd, and changed the atom.xsd to reference it, and changed the way we load the xsd into nokogiri (use File.open instead of File.read), so nokogiri can resolve the relative reference. Bingo, passes again.