### PR TITLE
Change Rails support to 5.2 - 6.1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,6 +25,11 @@ jobs:
             rails: 5.2
           - ruby: 2.7
             rails: 5.2
+          - ruby: 2.7
+            rails: 6.0
+          - ruby: 2.7
+            rails: 6.1
+
     env:
       RAILS_VERSION_SPEC: ${{ matrix.rails }}
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 * remove deprecated MultiSearcher class. Use ConcurrentSearcher instead, should be drop-in replacement in most cases.
 
+* Drop support for ruby earlier than 2.5, and rails earlier than 5.2. Add support for Rails 6.0 and 6.1. https://github.com/jrochkind/bento_search/pull/49
+
 ## 1.8.0
 
 * beforeSend param to ajax, see #30

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ end
 rails_version = if ENV['RAILS_VERSION_SPEC'] && !ENV['RAILS_VERSION_SPEC'].empty?
   ENV['RAILS_VERSION_SPEC'].dup
 else
-  "5.2.0"
+  "6.1"
 end
 
 gem 'rails', "~> #{rails_version}"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 bento_search provides an abstraction/normalization layer for querying and
 displaying results from external search engines, in Ruby on Rails. Works with
-Rails 3.x, 4.x, or 5.0. ruby 1.9.3+
+Rails 5.2 - 6.1, ruby 2.5+
 
 ### Goals: To help you
 

--- a/bento_search.gemspec
+++ b/bento_search.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.test_files = Dir["test/**/*"] - Dir["test/dummy/log/**/*"] - Dir["test/dummy/tmp/**/*"] - Dir["test/db/*.sqlite"] - Dir["test/dummy/db/**/*.sqlite3"]
 
-  s.add_dependency "rails", ">= 3.2.3", "< 6"
+  s.add_dependency "rails", ">= 5.2", "< 7"
   # s.add_dependency "jquery-rails"
   s.add_dependency "confstruct", "~> 1.0"
   s.add_dependency "httpclient", ">= 2.2.5", "< 3.0.0"

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -48,7 +48,7 @@ module Dummy
     config.assets.version = '1.0'
 
     # Avoid Rails deprecation warning
-    if Gem::Version.new(Rails.version).release >= Gem::Version.new("5.2.0")
+    if Gem::Version.new(Rails.version).release >= Gem::Version.new("5.2.0") && Gem::Version.new(Rails.version).release < Gem::Version.new("6.0.0")
       config.active_record.sqlite3.represent_boolean_as_integer = true
     end
 


### PR DESCRIPTION
We already stopped testing rails less than 5.2, to get Github Actions CI working. Rails 5.2 is last rails still getting any kind of support. Now we also change gemspec to say rails 5.2 is minimum.

We also introduce CI for Rails 6.0 and 6.1, and change gemspec to allow that.

Change README with accurate specification of ruby and rails versions.

Sorry for those still using Rails 3.x or 4.x or even earlier 5.0 with really old versions of ruby -- bento_search 2.0 will not support, mainly only because supporting them all in CI was too hard. Those are just really old, should be fine.

Rails 5.2 is supported by both previous and upcoming bento_search releases, so provides a bridge version.