### PR TITLE
remove bento_search.js sprockets wrapper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 * Change item header in default bento_search display from h4 to h3, to be more likely to be
   appropriate hieararchical level in expected usage. https://github.com/jrochkind/bento_search/pull/38
 
+* Removed `bento_search.js` wrapper sprockets JS file. If you had `//= require 'bento_search'` in your `application.js` or other sprockets pipeline, change to `//= require 'bento_search/ajax_load.js'` https://github.com/jrochkind/bento_search/pull/50
+
 ## 1.8.0
 
 * beforeSend param to ajax, see #30

--- a/app/assets/javascripts/bento_search.js
+++ b/app/assets/javascripts/bento_search.js
@@ -1,3 +1,0 @@
-// require all bento_search javascript. 
-//
-//= require_tree ./bento_search


### PR DESCRIPTION
Simplfiying JS management as we try to support webpacker too. We were never using this, it was just a wrapper for bento_search/ajax_load.js. For 2.0 release, just have people switch to requiring ajax_load.js directly.