### PR TITLE
Rails 7, 8 update (Ruby 3.1 - 3.3)

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,19 +19,24 @@ jobs:
     strategy:
       matrix:
         include:
-          - ruby: 2.5
-            rails: 5.2
-          - ruby: 2.6
-            rails: 5.2
-          - ruby: 2.7
-            rails: 5.2
-          - ruby: 2.7
-            rails: 6.0
-          - ruby: 2.7
-            rails: 6.1
-          - ruby: 3.0
-            rails: 6.1
-
+          - ruby: 3.1
+            rails: 7.1
+          - ruby: 3.2
+            rails: 7.1
+          - ruby: 3.3
+            rails: 7.1
+          - ruby: 3.1
+            rails: 7.2
+          - ruby: 3.2
+            rails: 7.2
+          - ruby: 3.3
+            rails: 7.2
+          - ruby: 3.1
+            rails: 8.0
+          - ruby: 3.2
+            rails: 8.0
+          - ruby: 3.3
+            rails: 8.0
     env:
       RAILS_VERSION_SPEC: ${{ matrix.rails }}
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -31,8 +31,6 @@ jobs:
             rails: 7.2
           - ruby: 3.3
             rails: 7.2
-          - ruby: 3.1
-            rails: 8.0
           - ruby: 3.2
             rails: 8.0
           - ruby: 3.3

--- a/Gemfile
+++ b/Gemfile
@@ -25,45 +25,12 @@ end
 rails_version = if ENV['RAILS_VERSION_SPEC'] && !ENV['RAILS_VERSION_SPEC'].empty?
   ENV['RAILS_VERSION_SPEC'].dup
 else
-  "6.1"
+  "7.1"
 end
 
 gem 'rails', "~> #{rails_version}"
-
-if Gem::Version.new(rails_version) > Gem::Version.new("4.2.999999")
-  # Only for Rails5, to restore tests we need, gah.
-  group "test" do
-    gem 'rails-controller-testing', '~> 1.0'
-  end
-end
-
-if Gem::Version.new(rails_version) < Gem::Version.new("5.0")
-  # Previous to Rails5, we need to include concurrent-ruby explicitly,
-  # in 5.x it's a dependency of Rails.
-  group "test" do
-    gem 'concurrent-ruby', '~> 1.0'
-  end
-end
-
-if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.0")
-  # Can't quite explain this one, but for ruby 1.9....
-  # https://github.com/rails/rails/issues/24749
-  gem 'mime-types', '2.6.2'
-
-  # New versions of public-suffix require newer ruby than 1.9.3,
-  # lock to 1.4.x one to test under 1.9.3
-  gem 'public_suffix', '~> 1.4.0'
-end
-
-if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.1")
-  gem 'nokogiri', '< 1.7'
-end
 
 gem "sqlite3", :platform => [:ruby, :mswin, :mingw]
 
 # for JRuby
 gem "activerecord-jdbcsqlite3-adapter", :platform => :jruby
-if Gem::Version.new(rails_version).release < Gem::Version.new("5.0")
-  # https://github.com/jruby/activerecord-jdbc-adapter/issues/859
-  gem "activerecord-jdbc-adapter", "~> 1.3.0", :platform => :jruby
-end

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 bento_search provides an abstraction/normalization layer for querying and
 displaying results from external search engines, in Ruby on Rails. Works with
-Rails 5.2 - 6.1, ruby 2.5 through 3.0.
+Rails 7.1 - 8.0, ruby 3.1 through 3.3.
 
 ### Goals: To help you
 
@@ -343,7 +343,7 @@ A class is included to convert an individual BentoSearch::ResultItem to
 the RIS format, suitable for import into EndNote, Refworks, etc.
 
 ~~~ruby
-    ris_data = RISCreator.new( bento_item ).export
+    ris_data = RisCreator.new( bento_item ).export
 ~~~
 
 Accomodating actual exports into the transactional flow of a web app can be

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ A class is included to convert an individual BentoSearch::ResultItem to
 the RIS format, suitable for import into EndNote, Refworks, etc.
 
 ~~~ruby
-    ris_data = RisCreator.new( bento_item ).export
+    ris_data = RISCreator.new( bento_item ).export
 ~~~
 
 Accomodating actual exports into the transactional flow of a web app can be

--- a/app/helpers/bento_search_helper.rb
+++ b/app/helpers/bento_search_helper.rb
@@ -137,9 +137,9 @@ module BentoSearchHelper
   # call partial directly:
   #  <%= render :partial => "bento_search/item_title", :object => item, :as => 'item'  %>
   def bento_item_title(item)
+    ActiveSupport::Deprecation.warn("#bento_item_title is deprecated.")
     render :partial => "bento_search/item_title", :object => item, :as => 'item'
   end
-  deprecate :bento_item_title
 
   # pass in 0-based rails current collection counter and a BentoSearch::Results,
   # calculates a user-displayable result set index label.

--- a/app/models/bento_search/RIS_creator.rb
+++ b/app/models/bento_search/RIS_creator.rb
@@ -24,7 +24,7 @@ module BentoSearch
   # But note this 'spec' is often ignored/violated, even by the vendors
   # who wrote it. Wikipedia at http://en.wikipedia.org/wiki/RIS_(file_format)#Tags
   # contains some additional tags not mentioned in 'spec'. 
-  class RisCreator
+  class RISCreator
     def initialize(i)
       @item = i
       @ris_format = translate_ris_format
@@ -162,6 +162,4 @@ module BentoSearch
       end        
     end
   end
-
-  RISCreator = RisCreator
 end

--- a/app/models/bento_search/ris_creator.rb
+++ b/app/models/bento_search/ris_creator.rb
@@ -24,7 +24,7 @@ module BentoSearch
   # But note this 'spec' is often ignored/violated, even by the vendors
   # who wrote it. Wikipedia at http://en.wikipedia.org/wiki/RIS_(file_format)#Tags
   # contains some additional tags not mentioned in 'spec'. 
-  class RISCreator
+  class RisCreator
     def initialize(i)
       @item = i
       @ris_format = translate_ris_format
@@ -161,6 +161,7 @@ module BentoSearch
         return nil
       end        
     end
-    
   end
+
+  RISCreator = RisCreator
 end

--- a/bento_search.gemspec
+++ b/bento_search.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.test_files = Dir["test/**/*"] - Dir["test/dummy/log/**/*"] - Dir["test/dummy/tmp/**/*"] - Dir["test/db/*.sqlite"] - Dir["test/dummy/db/**/*.sqlite3"]
 
-  s.add_dependency "rails", ">= 5.2", "< 7"
+  s.add_dependency "rails", ">= 5.2", "< 8"
   # s.add_dependency "jquery-rails"
   s.add_dependency "confstruct", "~> 1.0"
   s.add_dependency "httpclient", ">= 2.2.5", "< 3.0.0"

--- a/bento_search.gemspec
+++ b/bento_search.gemspec
@@ -15,7 +15,9 @@ Gem::Specification.new do |s|
 
   s.test_files = Dir["test/**/*"] - Dir["test/dummy/log/**/*"] - Dir["test/dummy/tmp/**/*"] - Dir["test/db/*.sqlite"] - Dir["test/dummy/db/**/*.sqlite3"]
 
-  s.add_dependency "rails", ">= 5.2", "< 8"
+  s.required_ruby_version = ">= 3.1"
+
+  s.add_dependency "rails", ">= 7.1", "< 9"
   # s.add_dependency "jquery-rails"
   s.add_dependency "confstruct", "~> 1.0"
   s.add_dependency "httpclient", ">= 2.2.5", "< 3.0.0"
@@ -28,4 +30,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "vcr", "~> 6.0"
   s.add_development_dependency "webmock", "~> 3.0"
+  s.add_development_dependency "rails-controller-testing"
 end

--- a/lib/bento_search/engine.rb
+++ b/lib/bento_search/engine.rb
@@ -2,6 +2,8 @@ module BentoSearch
   class Engine < ::Rails::Engine
     #isolate_namespace BentoSearch
 
-    config.assets.precompile += %w( bento_search/large_loader.gif )
+    if config.respond_to?(:assets)
+      config.assets.precompile += %w( bento_search/large_loader.gif )
+    end
   end
 end

--- a/lib/bento_search/version.rb
+++ b/lib/bento_search/version.rb
@@ -1,3 +1,3 @@
 module BentoSearch
-  VERSION = "2.0.0.rc1"
+  VERSION = "2.0.0.rc2"
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -41,11 +41,13 @@ module Dummy
     # like if you have constraints or database-specific column types
     # config.active_record.schema_format = :sql
 
-    # Enable the asset pipeline
-    config.assets.enabled = true
+    if config.respond_to?(:assets)
+      # Enable the asset pipeline
+      config.assets.enabled = true
 
-    # Version of your assets, change this if you want to expire all your assets
-    config.assets.version = '1.0'
+      # Version of your assets, change this if you want to expire all your assets
+      config.assets.version = '1.0'
+    end
 
     # Avoid Rails deprecation warning
     if Gem::Version.new(Rails.version).release >= Gem::Version.new("5.2.0") && Gem::Version.new(Rails.version).release < Gem::Version.new("6.0.0")

--- a/test/unit/ris_creator_test.rb
+++ b/test/unit/ris_creator_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 
 class RISCreatorTest < ActiveSupport::TestCase
-  RISCreator = BentoSearch::RisCreator
+  RISCreator = BentoSearch::RISCreator
   ResultItem = BentoSearch::ResultItem
   Author     = BentoSearch::Author
   

--- a/test/unit/ris_creator_test.rb
+++ b/test/unit/ris_creator_test.rb
@@ -1,7 +1,8 @@
 require 'test_helper'
 
+
 class RISCreatorTest < ActiveSupport::TestCase
-  RISCreator = BentoSearch::RISCreator
+  RISCreator = BentoSearch::RisCreator
   ResultItem = BentoSearch::ResultItem
   Author     = BentoSearch::Author
   


### PR DESCRIPTION
* Adds support for Rails 7.x and and below 9.x
* Adds support for ruby 3.x
* Drops support for Rails 6.x and below.
* Drops support for ruby 2.x and below